### PR TITLE
Generating main folders for android module

### DIFF
--- a/src/main/kotlin/ui/FileWriter.kt
+++ b/src/main/kotlin/ui/FileWriter.kt
@@ -26,4 +26,8 @@ class FileWriter() {
             }
         }
     }
+
+    fun mkdir(path: String) {
+        File(path).mkdir()
+    }
 }

--- a/src/main/kotlin/ui/Injector.kt
+++ b/src/main/kotlin/ui/Injector.kt
@@ -1,0 +1,34 @@
+package ui
+
+import ui.generators.BuildGradleGenerator
+import ui.generators.PackagesGenerator
+import ui.generators.android_modules.*
+import ui.generators.packages.JavaGenerator
+import ui.generators.packages.KotlinGenerator
+import ui.generators.project.GradleSettingsGenerator
+import ui.generators.project.ProjectBuildGradleGenerator
+
+object Injector {
+
+    private val fileWriter = FileWriter()
+    private val dependencyValidator = DependencyValidator()
+    private val moduleBlueprintFactory = ModuleBlueprintFactory()
+    private val buildGradleGenerator = BuildGradleGenerator()
+    private val gradleSettingsGenerator = GradleSettingsGenerator(fileWriter)
+    private val projectBuildGradleGenerator = ProjectBuildGradleGenerator()
+    private val stringResourcesGenerator: StringResourcesGenerator = StringResourcesGenerator()
+    private val imageResourcesGenerator: ImageResourcesGenerator = ImageResourcesGenerator()
+    private val layoutResourcesGenerator: LayoutResourcesGenerator = LayoutResourcesGenerator()
+    private val javaGenerator: JavaGenerator = JavaGenerator(fileWriter)
+    private val kotlinGenerator: KotlinGenerator = KotlinGenerator(fileWriter)
+    private val activityGenerator: ActivityGenerator = ActivityGenerator()
+    private val manifestGenerator: ManifestGenerator = ManifestGenerator()
+
+    private val androidModuleGenerator = AndroidModuleGenerator(stringResourcesGenerator, imageResourcesGenerator,
+            layoutResourcesGenerator, javaGenerator, kotlinGenerator, activityGenerator, manifestGenerator)
+
+    private val packagesGenerator = PackagesGenerator(javaGenerator, kotlinGenerator)
+
+    val modulesWriter = ModulesWriter(dependencyValidator, moduleBlueprintFactory, buildGradleGenerator,
+            gradleSettingsGenerator, projectBuildGradleGenerator, androidModuleGenerator, packagesGenerator, fileWriter)
+}

--- a/src/main/kotlin/ui/Injector.kt
+++ b/src/main/kotlin/ui/Injector.kt
@@ -25,7 +25,7 @@ object Injector {
     private val manifestGenerator: ManifestGenerator = ManifestGenerator()
 
     private val androidModuleGenerator = AndroidModuleGenerator(stringResourcesGenerator, imageResourcesGenerator,
-            layoutResourcesGenerator, javaGenerator, kotlinGenerator, activityGenerator, manifestGenerator)
+            layoutResourcesGenerator, javaGenerator, kotlinGenerator, activityGenerator, manifestGenerator, fileWriter)
 
     private val packagesGenerator = PackagesGenerator(javaGenerator, kotlinGenerator)
 

--- a/src/main/kotlin/ui/ModulesWriter.kt
+++ b/src/main/kotlin/ui/ModulesWriter.kt
@@ -23,7 +23,6 @@ import ui.generators.packages.KotlinGenerator
 import ui.generators.project.GradleSettingsGenerator
 import ui.generators.project.GradlewGenerator
 import ui.generators.project.ProjectBuildGradleGenerator
-import ui.models.AndroidModuleBlueprint
 import ui.models.ConfigPOJO
 import ui.models.ModuleBlueprint
 import utils.joinPath
@@ -34,6 +33,8 @@ class ModulesWriter(private val dependencyValidator: DependencyValidator,
                     private val buildGradleGenerator: BuildGradleGenerator,
                     private val gradleSettingsGenerator: GradleSettingsGenerator,
                     private val projectBuildGradleGenerator: ProjectBuildGradleGenerator,
+                    private val androidModuleGenerator: AndroidModuleGenerator,
+                    private val packagesGenerator: PackagesGenerator,
                     private val fileWriter: FileWriter) {
 
     fun generate(configStr: String) {
@@ -69,46 +70,9 @@ class ModulesWriter(private val dependencyValidator: DependencyValidator,
         }
 
         androidModuleBlueprints.forEach{ blueprint ->
-            writeAndroidModule(blueprint, configPOJO, projectRoot)
+            androidModuleGenerator.generate(blueprint)
             println("Done writing Android module " + blueprint.index)
         }
-    }
-
-    private fun writeAndroidModule(androidModuleBlueprint: AndroidModuleBlueprint, configPOJO: ConfigPOJO?, projectRoot: String) {
-        val moduleRootPath = projectRoot
-        val moduleRoot = moduleRootPath.joinPath(androidModuleBlueprint.getName())
-
-        val moduleRootFile = File(moduleRoot)
-        moduleRootFile.mkdir()
-
-        writeLibsFolder(moduleRootFile)
-
-        // TODO add one for Android package,
-        //writeBuildGradle(moduleRootFile, androidModuleBlueprint)
-        writeProguard()
-
-        val stringResourcesGenerator: StringResourcesGenerator = StringResourcesGenerator()
-        val imageResourcesGenerator: ImageResourcesGenerator = ImageResourcesGenerator()
-        val layoutResourcesGenerator: LayoutResourcesGenerator = LayoutResourcesGenerator()
-        val javaGenerator: JavaGenerator = JavaGenerator(fileWriter)
-        val kotlinGenerator: KotlinGenerator = KotlinGenerator(fileWriter)
-        val activityGenerator: ActivityGenerator = ActivityGenerator()
-        val manifestGenerator: ManifestGenerator = ManifestGenerator()
-
-        val packagesWriter = AndroidModuleGenerator(
-                stringResourcesGenerator,
-                imageResourcesGenerator,
-                layoutResourcesGenerator,
-                javaGenerator,
-                kotlinGenerator,
-                activityGenerator,
-                manifestGenerator)
-
-        packagesWriter.generate(androidModuleBlueprint)
-    }
-
-    private fun writeProguard() {
-
     }
 
     private fun writeModule(moduleBlueprint: ModuleBlueprint, configPOJO: ConfigPOJO) {
@@ -120,9 +84,7 @@ class ModulesWriter(private val dependencyValidator: DependencyValidator,
         writeLibsFolder(moduleRootFile)
         writeBuildGradle(moduleRootFile, moduleBlueprint)
 
-        val packagesWriter = PackagesGenerator(JavaGenerator(fileWriter), KotlinGenerator(fileWriter))
-
-        packagesWriter.writePackages(configPOJO, moduleBlueprint.index,
+        packagesGenerator.writePackages(configPOJO, moduleBlueprint.index,
                 moduleRoot + "/src/main/java/", File(moduleRootPath))
     }
 

--- a/src/main/kotlin/ui/PackagesGeneratorUI.kt
+++ b/src/main/kotlin/ui/PackagesGeneratorUI.kt
@@ -74,7 +74,7 @@ class PackagesGeneratorUI(private val modulesWriter: ModulesWriter) : JFrame() {
 
         @Language("JSON") val SAMPLE_CONFIG = "{\n" +
                 "  \"projectName\": \"genny\",\n" +
-                "  \"root\": \"/Users/bfarber/Desktop/modules/\",\n" +
+                "  \"root\": \"./modules/\",\n" +
                 "  \"numModules\": \"5\",\n" +
                 "  \"allMethods\": \"4000\",\n" +
                 "  \"javaPackageCount\": \"20\",\n" +

--- a/src/main/kotlin/ui/PackagesGeneratorUI.kt
+++ b/src/main/kotlin/ui/PackagesGeneratorUI.kt
@@ -93,13 +93,7 @@ class PackagesGeneratorUI(private val modulesWriter: ModulesWriter) : JFrame() {
 
             EventQueue.invokeLater {
                 try {
-                    val fileWriter = FileWriter()
-                    val frame = PackagesGeneratorUI(ModulesWriter(DependencyValidator(),
-                            ModuleBlueprintFactory(),
-                            BuildGradleGenerator(),
-                            GradleSettingsGenerator(fileWriter),
-                            ProjectBuildGradleGenerator(),
-                            fileWriter))
+                    val frame = PackagesGeneratorUI(Injector.modulesWriter)
                     frame.isVisible = true
                 } catch (e: Exception) {
                     e.printStackTrace()

--- a/src/main/kotlin/ui/generators/android_modules/AndroidModuleGenerator.kt
+++ b/src/main/kotlin/ui/generators/android_modules/AndroidModuleGenerator.kt
@@ -3,6 +3,7 @@ package ui.generators.android_modules
 import ui.generators.packages.JavaGenerator
 import ui.generators.packages.KotlinGenerator
 import ui.models.AndroidModuleBlueprint
+import java.io.File
 
 class AndroidModuleGenerator(private val stringResourcesGenerator: StringResourcesGenerator,
                              private val imageResourcesGenerator: ImageResourcesGenerator,
@@ -11,7 +12,21 @@ class AndroidModuleGenerator(private val stringResourcesGenerator: StringResourc
                              private val kotlinGenerator: KotlinGenerator,
                              private val activityGenerator: ActivityGenerator,
                              private val manifestGenerator: ManifestGenerator) {
+
+    /**
+     *  Generate android module, including module folder
+     */
     fun generate(blueprint: AndroidModuleBlueprint) {
+
+        val moduleRootFile = File(blueprint.moduleRoot)
+        moduleRootFile.mkdir()
+
+        writeLibsFolder(moduleRootFile)
+
+        // TODO add one for Android package,
+        //writeBuildGradle(moduleRootFile, androidModuleBlueprint)
+        writeProguard()
+
         val stringResources = stringResourcesGenerator.generate(blueprint)
         val imageResources = imageResourcesGenerator.generate(blueprint)
         val layouts = layoutResourcesGenerator.generate(blueprint, stringResources, imageResources)
@@ -20,6 +35,16 @@ class AndroidModuleGenerator(private val stringResourcesGenerator: StringResourc
         val methodsToCall: List<String> = listOf()
         val activities = activityGenerator.generate(blueprint, layouts, methodsToCall)
         manifestGenerator.generate(blueprint, activities)
+    }
+
+    private fun writeLibsFolder(moduleRootFile: File) {
+        // write libs
+        val libRoot = moduleRootFile.toString() + "/libs/"
+        File(libRoot).mkdir()
+    }
+
+    //TODO Write a generator for it and build.gradle, to keep this class concise
+    private fun writeProguard() {
 
     }
 }

--- a/src/main/kotlin/ui/generators/android_modules/AndroidModuleGenerator.kt
+++ b/src/main/kotlin/ui/generators/android_modules/AndroidModuleGenerator.kt
@@ -1,8 +1,10 @@
 package ui.generators.android_modules
 
+import ui.FileWriter
 import ui.generators.packages.JavaGenerator
 import ui.generators.packages.KotlinGenerator
 import ui.models.AndroidModuleBlueprint
+import utils.joinPath
 import java.io.File
 
 class AndroidModuleGenerator(private val stringResourcesGenerator: StringResourcesGenerator,
@@ -11,17 +13,15 @@ class AndroidModuleGenerator(private val stringResourcesGenerator: StringResourc
                              private val javaGenerator: JavaGenerator,
                              private val kotlinGenerator: KotlinGenerator,
                              private val activityGenerator: ActivityGenerator,
-                             private val manifestGenerator: ManifestGenerator) {
+                             private val manifestGenerator: ManifestGenerator,
+                             private val fileWriter: FileWriter) {
 
     /**
      *  Generate android module, including module folder
      */
     fun generate(blueprint: AndroidModuleBlueprint) {
 
-        val moduleRootFile = File(blueprint.moduleRoot)
-        moduleRootFile.mkdir()
-
-        writeLibsFolder(moduleRootFile)
+        generateMainFolders(blueprint)
 
         // TODO add one for Android package,
         //writeBuildGradle(moduleRootFile, androidModuleBlueprint)
@@ -37,10 +37,18 @@ class AndroidModuleGenerator(private val stringResourcesGenerator: StringResourc
         manifestGenerator.generate(blueprint, activities)
     }
 
-    private fun writeLibsFolder(moduleRootFile: File) {
-        // write libs
-        val libRoot = moduleRootFile.toString() + "/libs/"
-        File(libRoot).mkdir()
+    private fun generateMainFolders(blueprint: AndroidModuleBlueprint) {
+        val moduleRoot = blueprint.moduleRoot
+        fileWriter.mkdir(moduleRoot)
+        fileWriter.mkdir(moduleRoot.joinPath("libs"))
+        val srcPath = moduleRoot.joinPath("src")
+        fileWriter.mkdir(srcPath)
+        val mainPath = srcPath.joinPath("main")
+        fileWriter.mkdir(mainPath)
+        val codePath = mainPath.joinPath("java")
+        val resPath = mainPath.joinPath("res")
+        fileWriter.mkdir(codePath)
+        fileWriter.mkdir(resPath)
     }
 
     //TODO Write a generator for it and build.gradle, to keep this class concise

--- a/src/main/kotlin/ui/models/AndroidModuleBlueprint.kt
+++ b/src/main/kotlin/ui/models/AndroidModuleBlueprint.kt
@@ -1,8 +1,13 @@
 package ui.models
 
+import utils.joinPath
+
 data class AndroidModuleBlueprint(val index: Int,
                                   val numOfActivities: Int,
                                   val numOfStrings: Int,
-                                  val numOfImages: Int, val projectRoot: String) {
-    fun getName():String = "androidAppModule" + index
+                                  val numOfImages: Int,
+                                  val projectRoot: String) {
+
+    val name = "androidAppModule" + index
+    val moduleRoot = projectRoot.joinPath(name)
 }


### PR DESCRIPTION
Small refactoring to introduce manual dependency injection, to avoid creating instances in unexpected places and passing classes around.
Also changed default generation path to "./modules/", then after generation, it is easier to check generated code directly in the IntelliJ Idea

Also, `FileWriter` can now create folders, we should avoid calling `File` from anywhere except that class.