### PR TITLE
Generate a .dot file and parallelize Android Modules creation.

### DIFF
--- a/src/main/kotlin/com/google/androidstudiopoet/AndroidStudioPoet.kt
+++ b/src/main/kotlin/com/google/androidstudiopoet/AndroidStudioPoet.kt
@@ -167,8 +167,8 @@ class AndroidStudioPoet(private val modulesGenerator: SourceModuleGenerator, pri
             modulesGenerator.generate(projectBluePrint!!)
         }
         println("Finished in $timeSpent ms")
-        println("Dependency graph:")
-        projectBluePrint!!.printDependencies()
+        println("Dependency graph written to:")
+        projectBluePrint!!.saveDependencies()
         if (projectBluePrint!!.hasCircularDependencies()) {
             println("WARNING: there are circular dependencies")
         }

--- a/src/main/kotlin/com/google/androidstudiopoet/DependencyValidator.kt
+++ b/src/main/kotlin/com/google/androidstudiopoet/DependencyValidator.kt
@@ -42,9 +42,11 @@ class DependencyValidator {
             return true
         }
         if (javaDependsOnAndroid(from, to)) {
+            println("Java module ${dependency.from} cannot depend on Android module ${dependency.to}")
             return true
         }
         if (isApp(to)) {
+            println("Module ${dependency.from} cannot depend on Android app module ${dependency.to}")
             return true
         }
         return false
@@ -52,12 +54,18 @@ class DependencyValidator {
 
     private fun badIndexByType(moduleSplit: ModuleSplit, moduleCount: Int, androidModuleCount: Int): Boolean =
             when(moduleSplit.type) {
-                MODULE_TYPE -> badIndex(moduleSplit.index, moduleCount)
-                ANDROID_TYPE -> badIndex(moduleSplit.index, androidModuleCount)
+                MODULE_TYPE -> badIndex(moduleSplit, moduleCount)
+                ANDROID_TYPE -> badIndex(moduleSplit, androidModuleCount)
                 else -> true
             }
 
-    private fun badIndex(index: Int, count: Int) = (index < 0) || (index >= count)
+    private fun badIndex(split: ModuleSplit, count: Int) : Boolean {
+        if ((split.index < 0) || (split.index >= count)) {
+            println("Incorrect index for ${split.name()} in dependencies, should be in [0, $count)")
+            return true
+        }
+        return false
+    }
 
     private fun javaDependsOnAndroid(from: ModuleSplit, to: ModuleSplit): Boolean =
             from.type.equals(MODULE_TYPE) && to.type.equals(ANDROID_TYPE)
@@ -75,6 +83,10 @@ class DependencyValidator {
             }
             type = moduleName.substring(0, firstChar + 1)
             index = moduleName.substring(firstChar + 1).toInt()
+        }
+
+        fun name(): String {
+            return "$type$index"
         }
     }
 }

--- a/src/main/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToAndroidModuleConfigConverter.kt
+++ b/src/main/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToAndroidModuleConfigConverter.kt
@@ -21,7 +21,7 @@ import com.google.androidstudiopoet.input.ConfigPOJO
 
 class ConfigPojoToAndroidModuleConfigConverter {
     fun convert(config: ConfigPOJO, index: Int, productFlavorConfigs: List<FlavorConfig>,
-                buildTypes: List<BuildTypeConfig>, pureModuleDependencies: List<String>): AndroidModuleConfig {
+                buildTypes: List<BuildTypeConfig>): AndroidModuleConfig {
         return AndroidModuleConfig().apply {
             moduleName = getAndroidModuleName(index)
             javaPackageCount = config.javaPackageCount!!.toInt()
@@ -38,10 +38,8 @@ class ConfigPojoToAndroidModuleConfigConverter {
             generateTests = config.generateTests
             hasLaunchActivity = index == 0
 
-            val androidDependencies = (index + 1 until config.androidModules)
-                    .map { getAndroidModuleName(it) }
-
-            dependencies = (androidDependencies + pureModuleDependencies).map { DependencyConfig.ModuleDependencyConfig(it) }
+            val resolvedDependencies = config.resolvedDependencies[moduleName]
+            dependencies = resolvedDependencies?.sortedBy { it.to }!!.map{ dependency -> DependencyConfig.ModuleDependencyConfig(dependency.to) }
 
             this.buildTypes = buildTypes
             this.productFlavorConfigs = productFlavorConfigs

--- a/src/main/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToProjectConfigConverter.kt
+++ b/src/main/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToProjectConfigConverter.kt
@@ -33,8 +33,7 @@ class ConfigPojoToProjectConfigConverter(private val configPojoToModuleConfigCon
 
         val androidModulesConfigs = (0 until configPojo.androidModules)
                 .map {
-                    configPojoToAndroidModuleConfigConverter.convert(configPojo, it, productFlavors, buildTypes,
-                            pureModulesConfigs.map { it.moduleName })
+                    configPojoToAndroidModuleConfigConverter.convert(configPojo, it, productFlavors, buildTypes)
                 }
 
         val buildSystemConfig = configPojoToBuildSystemConfigConverter.convert(configPojo)

--- a/src/test/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToAndroidModuleConfigConverterTest.kt
+++ b/src/test/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToAndroidModuleConfigConverterTest.kt
@@ -17,6 +17,7 @@ limitations under the License.
 package com.google.androidstudiopoet.converters
 
 import com.google.androidstudiopoet.input.*
+import com.google.androidstudiopoet.models.FromToDependencyConfig
 import com.google.androidstudiopoet.testutils.*
 import org.junit.Test
 
@@ -35,6 +36,7 @@ private const val GENERATE_TESTS = true
 
 private const val ANDROID_MODULE_COUNT = 2
 private const val INDEX_1 = 1
+private const val ANDROID_MODULE_NAME_0 = "androidAppModule0"
 private const val ANDROID_MODULE_NAME_1 = "androidAppModule1"
 private const val MODULE_NAME_0 = "module0"
 private const val MODULE_NAME_1 = "module1"
@@ -65,13 +67,18 @@ class ConfigPojoToAndroidModuleConfigConverterTest {
 
         generateTests = GENERATE_TESTS
         androidModules = ANDROID_MODULE_COUNT
+        dependencies = listOf(FromToDependencyConfig(ANDROID_MODULE_NAME_0, MODULE_NAME_0),
+                FromToDependencyConfig(ANDROID_MODULE_NAME_0, MODULE_NAME_1),
+                FromToDependencyConfig(ANDROID_MODULE_NAME_1, MODULE_NAME_0),
+                FromToDependencyConfig(ANDROID_MODULE_NAME_1, MODULE_NAME_1),
+                FromToDependencyConfig(ANDROID_MODULE_NAME_0, ANDROID_MODULE_NAME_1))
     }
 
     private val converter = ConfigPojoToAndroidModuleConfigConverter()
 
     @Test
     fun `convert passes correct values to result AndroidModuleConfig`() {
-        val androidModuleConfig = converter.convert(configPOJO, INDEX_1, productFlavorConfigs, buildTypes, PURE_MODULE_LIST)
+        val androidModuleConfig = converter.convert(configPOJO, INDEX_1, productFlavorConfigs, buildTypes)
         assertOn(androidModuleConfig) {
             moduleName.assertEquals(ANDROID_MODULE_NAME_1)
             activityCount.assertEquals(ACTIVITY_COUNT)
@@ -95,7 +102,7 @@ class ConfigPojoToAndroidModuleConfigConverterTest {
 
     @Test
     fun `convert result AndroidModuleConfig that has launch activity when index == 0`() {
-        val androidModuleConfig = converter.convert(configPOJO, 0, productFlavorConfigs, buildTypes, PURE_MODULE_LIST)
+        val androidModuleConfig = converter.convert(configPOJO, 0, productFlavorConfigs, buildTypes)
         assertOn(androidModuleConfig) {
             hasLaunchActivity.assertTrue()
             dependencies!!.assertEquals(listOf(DependencyConfig.ModuleDependencyConfig(ANDROID_MODULE_NAME_1)) + PURE_MODULE_DEPENDENCY_LIST)

--- a/src/test/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToProjectConfigConverterTest.kt
+++ b/src/test/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToProjectConfigConverterTest.kt
@@ -66,9 +66,9 @@ class ConfigPojoToProjectConfigConverterTest {
         whenever(configPojoToModuleConfigConverter.convert(configPojo, 0)).thenReturn(moduleConfig0)
         whenever(configPojoToModuleConfigConverter.convert(configPojo, 1)).thenReturn(moduleConfig1)
         whenever(configPojoToAndroidModuleConfigConverter.convert(eq(configPojo), eq(0), eq(flavours),
-                eq(buildTypes), any())).thenReturn(androidModuleConfig0)
+                eq(buildTypes))).thenReturn(androidModuleConfig0)
         whenever(configPojoToAndroidModuleConfigConverter.convert(eq(configPojo), eq(1), eq(flavours),
-                eq(buildTypes), any())).thenReturn(androidModuleConfig1)
+                eq(buildTypes))).thenReturn(androidModuleConfig1)
         whenever(configPojoToFlavourConfigsConverter.convert(configPojo)).thenReturn(flavours)
         whenever(configPojoToBuildTypeConfigsConverter.convert(configPojo)).thenReturn(buildTypes)
         whenever(configPojoToBuildSystemConfigConverter.convert(configPojo)).thenReturn(buildSystemConfig0)


### PR DESCRIPTION
Dependency graph is now saved to a .dot file instead of printing
directly to stdout.

Also, now Android modules are created in parallel too.