### PR TITLE
Accept any string as a method for dependencies

### DIFF
--- a/src/main/kotlin/com/google/androidstudiopoet/ModuleBlueprintFactory.kt
+++ b/src/main/kotlin/com/google/androidstudiopoet/ModuleBlueprintFactory.kt
@@ -41,14 +41,14 @@ object ModuleBlueprintFactory {
                 moduleConfig.kotlinPackageCount, moduleConfig.kotlinClassCount, moduleConfig.kotlinMethodsPerClass, moduleConfig.extraLines, moduleConfig.generateTests)
         synchronized(moduleDependencyLock.getOrPut(moduleConfig.moduleName, { moduleConfig.moduleName })) {
             if (moduleDependencyCache[moduleConfig.moduleName] == null) {
-                moduleDependencyCache[moduleConfig.moduleName] = ModuleDependency(result.name, result.methodToCallFromOutside, DependencyMethod.IMPLEMENTATION)
+                moduleDependencyCache[moduleConfig.moduleName] = ModuleDependency(result.name, result.methodToCallFromOutside, DEFAULT_DEPENDENCY_METHOD)
             }
         }
         return result
     }
 
     private fun getModuleDependency(moduleName: String, projectRoot: String, javaPackageCount: Int, javaClassCount: Int, javaMethodsPerClass: Int,
-                                    kotlinPackageCount: Int, kotlinClassCount: Int, kotlinMethodsPerClass: Int, useKotlin: Boolean, dependencyMethod: DependencyMethod): ModuleDependency {
+                                    kotlinPackageCount: Int, kotlinClassCount: Int, kotlinMethodsPerClass: Int, useKotlin: Boolean, dependencyMethod: String): ModuleDependency {
         synchronized(moduleDependencyLock.getOrPut(moduleName, { moduleName })) {
             val cachedMethod = moduleDependencyCache[moduleName]
             if (cachedMethod != null) {
@@ -63,7 +63,7 @@ object ModuleBlueprintFactory {
 
     private fun getDependencyForModule(moduleName: String, projectRoot: String, javaPackageCount: Int, javaClassCount: Int,
                                        javaMethodsPerClass: Int, kotlinPackageCount: Int, kotlinClassCount: Int,
-                                       kotlinMethodsPerClass: Int, useKotlin: Boolean, dependencyMethod: DependencyMethod): ModuleDependency {
+                                       kotlinMethodsPerClass: Int, useKotlin: Boolean, dependencyMethod: String): ModuleDependency {
         /*
             Because method to call from outside doesn't depend on the dependencies, we can create ModuleBlueprint for
             dependency, return methodToCallFromOutside and forget about this module blueprint.
@@ -76,7 +76,7 @@ object ModuleBlueprintFactory {
 
     }
 
-    private fun getAndroidModuleDependency(projectRoot: String, androidModuleConfig: AndroidModuleConfig, dependencyMethod: DependencyMethod): AndroidModuleDependency {
+    private fun getAndroidModuleDependency(projectRoot: String, androidModuleConfig: AndroidModuleConfig, dependencyMethod: String): AndroidModuleDependency {
         /*
             Because method to call from outside and resources to refer don't depend on the dependencies, we can create AndroidModuleBlueprint for
             dependency, return methodToCallFromOutside with resourcesToRefer and forget about this module blueprint.
@@ -124,6 +124,5 @@ object ModuleBlueprintFactory {
 
 }
 
-private fun String?.toDependencyMethod(): DependencyMethod =
-        DependencyMethod.values().find { it.value == this } ?: DependencyMethod.IMPLEMENTATION
+private fun String?.toDependencyMethod(): String = this ?: DEFAULT_DEPENDENCY_METHOD
 

--- a/src/main/kotlin/com/google/androidstudiopoet/generators/BuildGradleGenerator.kt
+++ b/src/main/kotlin/com/google/androidstudiopoet/generators/BuildGradleGenerator.kt
@@ -23,7 +23,7 @@ import com.google.androidstudiopoet.utils.fold
 class BuildGradleGenerator {
     fun create(moduleBlueprint: ModuleBlueprint): String {
         return BuildGradle.print(moduleBlueprint.dependencies
-                .map { it -> "${it.method.value} project(':${it.name}')\n" }
+                .map { it -> "${it.method} project(':${it.name}')\n" }
                 .fold(), moduleBlueprint.useKotlin, moduleBlueprint.generateTests, moduleBlueprint.extraLines)
     }
 }

--- a/src/main/kotlin/com/google/androidstudiopoet/generators/android_modules/AndroidModuleBuildGradleGenerator.kt
+++ b/src/main/kotlin/com/google/androidstudiopoet/generators/android_modules/AndroidModuleBuildGradleGenerator.kt
@@ -111,7 +111,7 @@ class AndroidModuleBuildGradleGenerator(val fileWriter: FileWriter) {
     }
 
     private fun dependenciesClosure(blueprint: AndroidBuildGradleBlueprint): Closure {
-        val moduleDependenciesExpressions = blueprint.dependencies.map { Expression(it.method.value, "project(':${it.name}')") }
+        val moduleDependenciesExpressions = blueprint.dependencies.map { Expression(it.method, "project(':${it.name}')") }
         val librariesExpression = blueprint.libraries.map { Expression(it.method, "\"${it.name}\"") }
 
         val statements = listOf(Expression("implementation", "fileTree(dir: 'libs', include: ['*.jar'])")) +

--- a/src/main/kotlin/com/google/androidstudiopoet/models/Dependencies.kt
+++ b/src/main/kotlin/com/google/androidstudiopoet/models/Dependencies.kt
@@ -16,14 +16,11 @@ limitations under the License.
 
 package com.google.androidstudiopoet.models
 
-open class ModuleDependency(val name: String, val methodToCall: MethodToCall, val method: DependencyMethod)
+open class ModuleDependency(val name: String, val methodToCall: MethodToCall, val method: String)
 
-class AndroidModuleDependency(name: String, methodToCall: MethodToCall, method: DependencyMethod, val resourcesToRefer: ResourcesToRefer)
+class AndroidModuleDependency(name: String, methodToCall: MethodToCall, method: String, val resourcesToRefer: ResourcesToRefer)
     : ModuleDependency(name, methodToCall, method)
 
 data class LibraryDependency(val method: String, val name: String)
 
-enum class DependencyMethod(val value: String) {
-    API("api"),
-    IMPLEMENTATION("implementation")
-}
+const val DEFAULT_DEPENDENCY_METHOD = "implementation"


### PR DESCRIPTION
Having an enum was wrong approach, because it can't cover cases with custom flavors, dimensions or build types. String looses constraints, but we'll need to add more validation later.