### PR TITLE
Generate Android modules in parallel

### DIFF
--- a/src/main/kotlin/com/google/androidstudiopoet/generators/SourceModuleGenerator.kt
+++ b/src/main/kotlin/com/google/androidstudiopoet/generators/SourceModuleGenerator.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.experimental.Job
 import kotlinx.coroutines.experimental.launch
 import kotlinx.coroutines.experimental.runBlocking
 import java.io.File
+import java.util.*
 
 class SourceModuleGenerator(private val moduleBuildGradleGenerator: ModuleBuildGradleGenerator,
                             private val gradleSettingsGenerator: GradleSettingsGenerator,
@@ -50,15 +51,18 @@ class SourceModuleGenerator(private val moduleBuildGradleGenerator: ModuleBuildG
             }
             allJobs.add(job)
         }
+        var randomCount: Long = 0
+        projectBlueprint.androidModuleBlueprints.forEach{ blueprint ->
+            val random = Random(randomCount++)
+            val job = launch {
+                androidModuleGenerator.generate(blueprint, random)
+                println("Done writing Android module " + blueprint.name)
+            }
+            allJobs.add(job)
+        }
         for (job in allJobs) {
             job.join()
         }
-
-        projectBlueprint.androidModuleBlueprints.forEach{ blueprint ->
-            androidModuleGenerator.generate(blueprint)
-            println("Done writing Android module " + blueprint.name)
-        }
-
     }
 
     private fun writeModule(moduleBlueprint: ModuleBlueprint) {

--- a/src/main/kotlin/com/google/androidstudiopoet/generators/android_modules/AndroidModuleGenerator.kt
+++ b/src/main/kotlin/com/google/androidstudiopoet/generators/android_modules/AndroidModuleGenerator.kt
@@ -21,6 +21,7 @@ import com.google.androidstudiopoet.generators.android_modules.resources.Resourc
 import com.google.androidstudiopoet.models.AndroidModuleBlueprint
 import com.google.androidstudiopoet.utils.joinPath
 import com.google.androidstudiopoet.writers.FileWriter
+import java.util.*
 
 class AndroidModuleGenerator(private val resourcesGenerator: ResourcesGenerator,
                              private val packagesGenerator: PackagesGenerator,
@@ -33,12 +34,12 @@ class AndroidModuleGenerator(private val resourcesGenerator: ResourcesGenerator,
     /**
      *  Generate android module, including module folder
      */
-    fun generate(blueprint: AndroidModuleBlueprint) {
+    fun generate(blueprint: AndroidModuleBlueprint, random: Random) {
         generateMainFolders(blueprint)
 
         proguardGenerator.generate(blueprint)
         buildGradleGenerator.generate(blueprint.buildGradleBlueprint)
-        blueprint.resourcesBlueprint?.let { resourcesGenerator.generate(it) }
+        blueprint.resourcesBlueprint?.let { resourcesGenerator.generate(it, random) }
         packagesGenerator.writePackages(blueprint.packagesBlueprint)
         blueprint.activityBlueprints.forEach({ activityGenerator.generate(it) })
         manifestGenerator.generate(blueprint)

--- a/src/main/kotlin/com/google/androidstudiopoet/generators/android_modules/resources/ImagesGenerator.kt
+++ b/src/main/kotlin/com/google/androidstudiopoet/generators/android_modules/resources/ImagesGenerator.kt
@@ -20,6 +20,7 @@ import com.google.androidstudiopoet.utils.joinPath
 import com.google.androidstudiopoet.writers.FileWriter
 import java.awt.image.BufferedImage
 import java.io.File
+import java.util.*
 import javax.imageio.ImageIO
 
 class ImagesGenerator(val fileWriter: FileWriter) {
@@ -27,32 +28,32 @@ class ImagesGenerator(val fileWriter: FileWriter) {
     /**
      * generates image resources by blueprint, returns list of image names to refer later.
      */
-    fun generate(blueprint: ResourcesBlueprint) {
+    fun generate(blueprint: ResourcesBlueprint, random: Random) {
 
         val imagesDir = blueprint.resDirPath.joinPath("drawable")
 
         fileWriter.mkdir(imagesDir)
 
         blueprint.imageNames.forEach { imageName ->
-            val image = generateRandomImage()
+            val image = generateRandomImage(random)
 
             ImageIO.write(image,
                     "png",
-                    File(imagesDir, imageName + ".png"))
+                    File(imagesDir, "$imageName.png"))
         }
     }
 
-    private fun generateRandomImage(): BufferedImage {
+    private fun generateRandomImage(random: Random): BufferedImage {
         // Create buffered image object
         val img = BufferedImage(100, 100, BufferedImage.TYPE_INT_ARGB)
 
         // create random values pixel by pixel
         for (y in 0 until 100) {
             for (x in 0 until 100) {
-                val a = (Math.random() * 256).toInt() //generating
-                val r = (Math.random() * 256).toInt() //values
-                val g = (Math.random() * 256).toInt() //less than
-                val b = (Math.random() * 256).toInt() //256
+                val a = random.nextInt(256) //generating
+                val r = random.nextInt(256) //values
+                val g = random.nextInt(256) //less than
+                val b = random.nextInt(256) //256
 
                 val p = a shl 24 or (r shl 16) or (g shl 8) or b //pixel
 

--- a/src/main/kotlin/com/google/androidstudiopoet/generators/android_modules/resources/ResourcesGenerator.kt
+++ b/src/main/kotlin/com/google/androidstudiopoet/generators/android_modules/resources/ResourcesGenerator.kt
@@ -18,14 +18,15 @@ package com.google.androidstudiopoet.generators.android_modules.resources
 
 import com.google.androidstudiopoet.models.ResourcesBlueprint
 import com.google.androidstudiopoet.writers.FileWriter
+import java.util.*
 
 class ResourcesGenerator(private val stringResourcesGenerator: StringResourcesGenerator,
                          private val imageResourcesGenerator: ImagesGenerator,
                          private val layoutResourcesGenerator: LayoutResourcesGenerator,
                          private val fileWriter: FileWriter) {
-    fun generate(blueprint: ResourcesBlueprint) {
+    fun generate(blueprint: ResourcesBlueprint, random: Random) {
         stringResourcesGenerator.generate(blueprint)
-        imageResourcesGenerator.generate(blueprint)
+        imageResourcesGenerator.generate(blueprint, random)
         fileWriter.mkdir(blueprint.layoutsDir)
         blueprint.layoutBlueprints.forEach { layoutResourcesGenerator.generate(it) }
     }


### PR DESCRIPTION
Now Android modules are also created in parallel. This reduces time
considerably. Went from ~6 seconds to ~1 second to generate a project
with 200 Android modules.