### PR TITLE
Fix NPE, create blueprints in parallel and reduce verbosity

### DIFF
--- a/src/main/kotlin/com/google/androidstudiopoet/AndroidStudioPoet.kt
+++ b/src/main/kotlin/com/google/androidstudiopoet/AndroidStudioPoet.kt
@@ -165,13 +165,12 @@ class AndroidStudioPoet(private val modulesGenerator: SourceModuleGenerator, pri
         val timeSpent = measureTimeMillis {
             projectBluePrint = ProjectBlueprint(projectConfig)
             modulesGenerator.generate(projectBluePrint!!)
+            projectBluePrint!!.saveDependencies()
+            if (projectBluePrint!!.hasCircularDependencies()) {
+                println("WARNING: there are circular dependencies")
+            }
         }
         println("Finished in $timeSpent ms")
-        println("Dependency graph written to:")
-        projectBluePrint!!.saveDependencies()
-        if (projectBluePrint!!.hasCircularDependencies()) {
-            println("WARNING: there are circular dependencies")
-        }
     }
 
     private fun createTitleLabel(): JLabel {

--- a/src/main/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToAndroidModuleConfigConverter.kt
+++ b/src/main/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToAndroidModuleConfigConverter.kt
@@ -39,7 +39,7 @@ class ConfigPojoToAndroidModuleConfigConverter {
             hasLaunchActivity = index == 0
 
             val resolvedDependencies = config.resolvedDependencies[moduleName]
-            dependencies = resolvedDependencies?.sortedBy { it.to }!!.map{ dependency -> DependencyConfig.ModuleDependencyConfig(dependency.to) }
+            dependencies = resolvedDependencies?.sortedBy { it.to }?.map { dependency -> DependencyConfig.ModuleDependencyConfig(dependency.to) } ?: emptyList()
 
             this.buildTypes = buildTypes
             this.productFlavorConfigs = productFlavorConfigs

--- a/src/main/kotlin/com/google/androidstudiopoet/generators/android_modules/ActivityGenerator.kt
+++ b/src/main/kotlin/com/google/androidstudiopoet/generators/android_modules/ActivityGenerator.kt
@@ -37,8 +37,6 @@ class ActivityGenerator(var fileWriter: FileWriter) {
                 .build()
 
         val javaFile = JavaFile.builder(blueprint.packageName, activityClass).build()
-
-        println("${blueprint.where}/${blueprint.className}.java")
         fileWriter.writeToFile(javaFile.toString(), "${blueprint.where}/${blueprint.className}.java")
 
     }


### PR DESCRIPTION
- Fix a NPE when the project has orphaned modules (default config has
this issue)

- Reduce execution time by:
  - creating Android blueprints in parallel
  - generating modules in reverse order (ideally, topologial sort should
  be used, but for current implementation, reverse order is good)

- Reduce verbosity by
  - Remove some messages
  - Show percentage of modules finished instead of a message for each
  module