### PR TITLE
Do not delete files in symlinks when overwriting project

### DIFF
--- a/src/main/kotlin/com/google/androidstudiopoet/writers/AbstractWriter.kt
+++ b/src/main/kotlin/com/google/androidstudiopoet/writers/AbstractWriter.kt
@@ -15,7 +15,7 @@ interface AbstractWriter {
 
     fun delete(path: String) {
         val file = File(path)
-        if (file.isDirectory && !FileUtils.isSymlink(file)) {
+        if (!FileUtils.isSymlink(file)) {
             file.listFiles()?.forEach { delete(it.absolutePath) }
         }
         file.delete()

--- a/src/main/kotlin/com/google/androidstudiopoet/writers/AbstractWriter.kt
+++ b/src/main/kotlin/com/google/androidstudiopoet/writers/AbstractWriter.kt
@@ -1,5 +1,6 @@
 package com.google.androidstudiopoet.writers
 
+import org.apache.commons.io.FileUtils
 import java.io.File
 
 interface AbstractWriter {
@@ -14,7 +15,9 @@ interface AbstractWriter {
 
     fun delete(path: String) {
         val file = File(path)
-        file.listFiles()?.forEach { delete(it.absolutePath) }
+        if (file.isDirectory && !FileUtils.isSymlink(file)) {
+            file.listFiles()?.forEach { delete(it.absolutePath) }
+        }
         file.delete()
     }
 }


### PR DESCRIPTION
The current behavior of generating a new project deletes all the files in the original directory before writing new contents. If there are symlinks to other directories, `AbstractWriter#delete` follows the symlink and deletes the files in them too. 

This caused problems when I create symlinks to large directories like the SDK, which were completely wiped out when I generate a new project.