### PR TITLE
Download gradle-bin distribution instead of gradle-all

### DIFF
--- a/src/main/kotlin/com/google/androidstudiopoet/generators/project/GradlewGenerator.kt
+++ b/src/main/kotlin/com/google/androidstudiopoet/generators/project/GradlewGenerator.kt
@@ -90,6 +90,6 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-$gradleVersion-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-$gradleVersion-bin.zip
          """
 }


### PR DESCRIPTION
For benchmarking, there's no need for Gradle sources and docs in the generated project. This is a difference of ~33MB.

```
$ ls -lah gradle-4.7-*
-rw-r--r-- 1 jingwen primarygroup 105M May  1 17:10 gradle-4.7-all.zip
-rw-r--r-- 1 jingwen primarygroup  72M May  1 17:10 gradle-4.7-bin.zip
```