### PR TITLE
Add method to dependencies and topologies in compact input

### DIFF
--- a/src/main/kotlin/com/google/androidstudiopoet/AndroidStudioPoet.kt
+++ b/src/main/kotlin/com/google/androidstudiopoet/AndroidStudioPoet.kt
@@ -163,7 +163,7 @@ class AndroidStudioPoet(private val modulesGenerator: SourceModuleGenerator, pri
     }
 
     private fun startGeneration(projectConfig: ProjectConfig) {
-        var projectBluePrint: ProjectBlueprint? = null
+        var projectBluePrint: ProjectBlueprint?
         val timeSpent = measureTimeMillis {
             projectBluePrint = ProjectBlueprint(projectConfig)
             modulesGenerator.generate(projectBluePrint!!)

--- a/src/main/kotlin/com/google/androidstudiopoet/Defaults.kt
+++ b/src/main/kotlin/com/google/androidstudiopoet/Defaults.kt
@@ -16,6 +16,7 @@ limitations under the License.
 
 package com.google.androidstudiopoet
 
-val DEFAULT_KOTLIN_VERSION = "1.1.60"
-val DEFAULT_AGP_VERSION = "3.0.1"
+const val DEFAULT_KOTLIN_VERSION = "1.1.60"
+const val DEFAULT_AGP_VERSION = "3.0.1"
+const val DEFAULT_DEPENDENCY_METHOD = "implementation"
 

--- a/src/main/kotlin/com/google/androidstudiopoet/ModuleBlueprintFactory.kt
+++ b/src/main/kotlin/com/google/androidstudiopoet/ModuleBlueprintFactory.kt
@@ -23,110 +23,32 @@ import com.google.androidstudiopoet.input.ModuleConfig
 import com.google.androidstudiopoet.models.*
 
 object ModuleBlueprintFactory {
-
     // Store if a ModuleDependency was already computed
-    private var moduleDependencyCache: MutableMap<String, ModuleDependency?> = mutableMapOf()
-    private var androidModuleDependencyCache: MutableMap<String, AndroidModuleDependency?> = mutableMapOf()
+    private val tempBlueprintCache: MutableMap<String, AbstractModuleBlueprint> = mutableMapOf()
     // Used to synchronize cache elements (can be one per item since each is independent)
-    private var moduleDependencyLock: MutableMap<String, Any> = mutableMapOf()
+    private val moduleNameLock: MutableMap<String, Any> = mutableMapOf()
 
-    fun create(moduleConfig: ModuleConfig, projectRoot: String): ModuleBlueprint {
-        val moduleDependencies = moduleConfig.dependencies
-                ?.map {
-                    when(it) {
-                        is DependencyConfig.ModuleDependencyConfig -> getModuleDependency(it.moduleName, projectRoot, moduleConfig.javaPackageCount, moduleConfig.javaClassCount,
-                                moduleConfig.javaMethodsPerClass, moduleConfig.kotlinPackageCount,
-                                moduleConfig.kotlinClassCount, moduleConfig.kotlinMethodsPerClass, moduleConfig.useKotlin,
-                                it.method.toDependencyMethod())
-                        is DependencyConfig.LibraryDependencyConfig -> LibraryDependency(it.method.toDependencyMethod(), it.library)
-                    }
-
-                } ?: listOf()
-        val result = ModuleBlueprint(moduleConfig.moduleName, projectRoot, moduleConfig.useKotlin, moduleDependencies.toSet(),
+    fun create(moduleConfig: ModuleConfig, projectRoot: String, configMap: Map<String, ModuleConfig>): ModuleBlueprint {
+        val dependencies = createDependencies(projectRoot, moduleConfig, configMap)
+        return ModuleBlueprint(moduleConfig.moduleName, projectRoot, moduleConfig.useKotlin, dependencies,
                 moduleConfig.javaPackageCount, moduleConfig.javaClassCount, moduleConfig.javaMethodsPerClass,
-                moduleConfig.kotlinPackageCount, moduleConfig.kotlinClassCount, moduleConfig.kotlinMethodsPerClass, moduleConfig.extraLines, moduleConfig.generateTests)
-        synchronized(moduleDependencyLock.getOrPut(moduleConfig.moduleName, { moduleConfig.moduleName })) {
-            if (moduleDependencyCache[moduleConfig.moduleName] == null) {
-                moduleDependencyCache[moduleConfig.moduleName] = ModuleDependency(result.name, result.methodToCallFromOutside, DEFAULT_DEPENDENCY_METHOD)
-            }
-        }
-        return result
+                moduleConfig.kotlinPackageCount, moduleConfig.kotlinClassCount, moduleConfig.kotlinMethodsPerClass,
+                moduleConfig.extraLines, moduleConfig.generateTests)
     }
 
-    private fun getModuleDependency(moduleName: String, projectRoot: String, javaPackageCount: Int, javaClassCount: Int, javaMethodsPerClass: Int,
-                                    kotlinPackageCount: Int, kotlinClassCount: Int, kotlinMethodsPerClass: Int, useKotlin: Boolean, dependencyMethod: String): ModuleDependency {
-        synchronized(moduleDependencyLock.getOrPut(moduleName, { moduleName })) {
-            val cachedMethod = moduleDependencyCache[moduleName]
-            if (cachedMethod != null) {
-                return cachedMethod
-            }
-            val newMethodDependency = getDependencyForModule(moduleName, projectRoot, javaPackageCount, javaClassCount,
-                    javaMethodsPerClass, kotlinPackageCount, kotlinClassCount, kotlinMethodsPerClass, useKotlin, dependencyMethod)
-            moduleDependencyCache[moduleName] = newMethodDependency
-            return newMethodDependency
-        }
+    private fun createWithoutDependencies(moduleConfig: ModuleConfig, projectRoot: String): ModuleBlueprint {
+        return ModuleBlueprint(moduleConfig.moduleName, projectRoot, moduleConfig.useKotlin, setOf(),
+                moduleConfig.javaPackageCount, moduleConfig.javaClassCount, moduleConfig.javaMethodsPerClass,
+                moduleConfig.kotlinPackageCount, moduleConfig.kotlinClassCount, moduleConfig.kotlinMethodsPerClass,
+                moduleConfig.extraLines, moduleConfig.generateTests)
     }
 
-    private fun getDependencyForModule(moduleName: String, projectRoot: String, javaPackageCount: Int, javaClassCount: Int,
-                                       javaMethodsPerClass: Int, kotlinPackageCount: Int, kotlinClassCount: Int,
-                                       kotlinMethodsPerClass: Int, useKotlin: Boolean, dependencyMethod: String): ModuleDependency {
-        /*
-            Because method to call from outside doesn't depend on the dependencies, we can create ModuleBlueprint for
-            dependency, return methodToCallFromOutside and forget about this module blueprint.
-            WARNING: creation of ModuleBlueprint could be expensive
-         */
-        val tempModuleBlueprint = ModuleBlueprint(moduleName, projectRoot, useKotlin, setOf(),
-                javaPackageCount, javaClassCount, javaMethodsPerClass, kotlinPackageCount, kotlinClassCount,
-                kotlinMethodsPerClass, null, false)
-        return ModuleDependency(tempModuleBlueprint.name, tempModuleBlueprint.methodToCallFromOutside, dependencyMethod)
-
-    }
-
-    private fun getAndroidModuleDependency(projectRoot: String, androidModuleConfig: AndroidModuleConfig, dependencyMethod: String): AndroidModuleDependency {
-        /*
-            Because method to call from outside and resources to refer don't depend on the dependencies, we can create AndroidModuleBlueprint for
-            dependency, return methodToCallFromOutside with resourcesToRefer and forget about this module blueprint.
-            WARNING: creation of AndroidModuleBlueprint could be expensive
-        */
-        synchronized(moduleDependencyLock.getOrPut(androidModuleConfig.moduleName, { androidModuleConfig.moduleName })) {
-            val cachedMethod = androidModuleDependencyCache[androidModuleConfig.moduleName]
-            if (cachedMethod != null) {
-                return cachedMethod
-            }
-            val moduleBlueprint = createAndroidModule(projectRoot, androidModuleConfig, listOf())
-            val newMethodDependency = AndroidModuleDependency(moduleBlueprint.name, moduleBlueprint.methodToCallFromOutside, dependencyMethod,
-                    moduleBlueprint.resourcesToReferFromOutside)
-            androidModuleDependencyCache[androidModuleConfig.moduleName] = newMethodDependency
-            return newMethodDependency
-        }
-    }
-
-    fun createAndroidModule(projectRoot: String, androidModuleConfig: AndroidModuleConfig, moduleConfigs: List<ModuleConfig>):
-            AndroidModuleBlueprint {
-
-        val moduleDependencies = androidModuleConfig.dependencies
-                ?.mapNotNull { dependencyConfig ->
-                    when (dependencyConfig) {
-                        is DependencyConfig.ModuleDependencyConfig -> {
-                            val moduleConfigToDependOn = moduleConfigs.find { it.moduleName == dependencyConfig.moduleName }
-                            return@mapNotNull when (moduleConfigToDependOn) {
-                                is AndroidModuleConfig -> getAndroidModuleDependency(projectRoot, moduleConfigToDependOn, dependencyConfig.method.toDependencyMethod())
-                                is ModuleConfig -> getModuleDependency(moduleConfigToDependOn.moduleName, projectRoot, androidModuleConfig.javaPackageCount, androidModuleConfig.javaClassCount,
-                                        androidModuleConfig.javaMethodsPerClass, androidModuleConfig.kotlinPackageCount,
-                                        androidModuleConfig.kotlinClassCount, androidModuleConfig.kotlinMethodsPerClass, androidModuleConfig.useKotlin, dependencyConfig.method.toDependencyMethod())
-                                else -> null
-                            }
-                        }
-                        is DependencyConfig.LibraryDependencyConfig -> LibraryDependency(dependencyConfig.method.toDependencyMethod(), dependencyConfig.library)
-                    }
-
-
-                } ?: listOf()
-
-        return AndroidModuleBlueprint(androidModuleConfig.moduleName,
+    fun createAndroidModule(projectRoot: String, androidModuleConfig: AndroidModuleConfig, configMap: Map<String, ModuleConfig>): AndroidModuleBlueprint {
+        val dependencies = createDependencies(projectRoot, androidModuleConfig, configMap)
+        return  AndroidModuleBlueprint(androidModuleConfig.moduleName,
                 androidModuleConfig.activityCount, androidModuleConfig.resourcesConfig,
                 projectRoot, androidModuleConfig.hasLaunchActivity, androidModuleConfig.useKotlin,
-                moduleDependencies.toSet(), androidModuleConfig.productFlavorConfigs, androidModuleConfig.buildTypes,
+                dependencies, androidModuleConfig.productFlavorConfigs, androidModuleConfig.buildTypes,
                 androidModuleConfig.javaPackageCount, androidModuleConfig.javaClassCount,
                 androidModuleConfig.javaMethodsPerClass, androidModuleConfig.kotlinPackageCount,
                 androidModuleConfig.kotlinClassCount, androidModuleConfig.kotlinMethodsPerClass,
@@ -136,10 +58,70 @@ object ModuleBlueprintFactory {
                 androidModuleConfig.androidBuildConfig ?: AndroidBuildConfig())
     }
 
+    private fun createAndroidModuleWithoutDependencies(projectRoot: String, androidModuleConfig: AndroidModuleConfig):
+            AndroidModuleBlueprint = AndroidModuleBlueprint(androidModuleConfig.moduleName,
+                    androidModuleConfig.activityCount, androidModuleConfig.resourcesConfig,
+                    projectRoot, androidModuleConfig.hasLaunchActivity, androidModuleConfig.useKotlin,
+                    setOf(), androidModuleConfig.productFlavorConfigs, androidModuleConfig.buildTypes,
+                    androidModuleConfig.javaPackageCount, androidModuleConfig.javaClassCount,
+                    androidModuleConfig.javaMethodsPerClass, androidModuleConfig.kotlinPackageCount,
+                    androidModuleConfig.kotlinClassCount, androidModuleConfig.kotlinMethodsPerClass,
+                    androidModuleConfig.extraLines,
+                    androidModuleConfig.generateTests,
+                    androidModuleConfig.dataBindingConfig,
+                    androidModuleConfig.androidBuildConfig ?: AndroidBuildConfig())
+
+    private fun createDependencies(projectRoot: String, moduleConfig: ModuleConfig, configMap: Map<String, ModuleConfig>): Set<Dependency> {
+        val moduleDependencies = moduleConfig.dependencies
+                ?.mapNotNull { dependencyConfig ->
+                    when (dependencyConfig) {
+                        is DependencyConfig.ModuleDependencyConfig -> {
+                            val dependencyModuleConfig = configMap[dependencyConfig.moduleName]
+                            return@mapNotNull when (dependencyModuleConfig) {
+                                is AndroidModuleConfig -> {
+                                    val methodToCall = getMethodToCall(projectRoot, dependencyModuleConfig)
+                                    val resourcesToRefer = getResourcesToRefer(projectRoot, dependencyModuleConfig)
+                                    AndroidModuleDependency(dependencyConfig.moduleName, methodToCall, dependencyConfig.method.toDependencyMethod(), resourcesToRefer)
+                                }
+                                is ModuleConfig -> {
+                                    val methodToCall = getMethodToCall(projectRoot, dependencyModuleConfig)
+                                    ModuleDependency(dependencyConfig.moduleName, methodToCall, dependencyConfig.method.toDependencyMethod())
+                                }
+                                else -> null
+                            }
+                        }
+                        is DependencyConfig.LibraryDependencyConfig -> LibraryDependency(dependencyConfig.method.toDependencyMethod(), dependencyConfig.library)
+                    }
+                } ?: listOf()
+        return moduleDependencies.toHashSet()
+    }
+
+    private fun getResourcesToRefer(projectRoot: String, moduleConfig: ModuleConfig): ResourcesToRefer {
+        val blueprint = getCachedBlueprint(projectRoot, moduleConfig)
+        return (blueprint as AndroidModuleBlueprint).resourcesToReferFromOutside
+    }
+
+
+    private fun getMethodToCall(projectRoot: String, moduleConfig: ModuleConfig) = getCachedBlueprint(projectRoot, moduleConfig).methodToCallFromOutside
+
+    private fun getCachedBlueprint(projectRoot: String, moduleConfig: ModuleConfig): AbstractModuleBlueprint {
+        synchronized(moduleNameLock.getOrPut(moduleConfig.moduleName, { moduleConfig.moduleName })) {
+            var cachedBlueprint = tempBlueprintCache[moduleConfig.moduleName]
+            if (cachedBlueprint == null) {
+                cachedBlueprint =
+                        if (moduleConfig is AndroidModuleConfig)
+                            createAndroidModuleWithoutDependencies(projectRoot, moduleConfig)
+                        else
+                            createWithoutDependencies(moduleConfig, projectRoot)
+                tempBlueprintCache[moduleConfig.moduleName] = cachedBlueprint
+            }
+            return cachedBlueprint
+        }
+    }
+
     fun initCache() {
-        moduleDependencyCache = mutableMapOf()
-        moduleDependencyLock = mutableMapOf()
-        androidModuleDependencyCache = mutableMapOf()
+        tempBlueprintCache.clear()
+        moduleNameLock.clear()
     }
 }
 

--- a/src/main/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToAndroidModuleConfigConverter.kt
+++ b/src/main/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToAndroidModuleConfigConverter.kt
@@ -39,7 +39,7 @@ class ConfigPojoToAndroidModuleConfigConverter {
             hasLaunchActivity = index == 0
 
             val resolvedDependencies = config.resolvedDependencies[moduleName]
-            dependencies = resolvedDependencies?.sortedBy { it.to }?.map { dependency -> DependencyConfig.ModuleDependencyConfig(dependency.to) } ?: emptyList()
+            dependencies = resolvedDependencies?.sortedBy { it.to }?.map { dependency -> DependencyConfig.ModuleDependencyConfig(dependency.to, dependency.method) } ?: emptyList()
 
             this.buildTypes = buildTypes
             this.productFlavorConfigs = productFlavorConfigs

--- a/src/main/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToModuleConfigConverter.kt
+++ b/src/main/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToModuleConfigConverter.kt
@@ -37,7 +37,7 @@ class ConfigPojoToModuleConfigConverter {
              generateTests = config.generateTests
 
              moduleName = "module$index"
-             dependencies = config.resolvedDependencies[moduleName]?.map {  DependencyConfig.ModuleDependencyConfig(it.to) } ?: listOf()
+             dependencies = config.resolvedDependencies[moduleName]?.map {  DependencyConfig.ModuleDependencyConfig(it.to, it.method) } ?: listOf()
         }
     }
 }

--- a/src/main/kotlin/com/google/androidstudiopoet/models/AbstractModuleBlueprint.kt
+++ b/src/main/kotlin/com/google/androidstudiopoet/models/AbstractModuleBlueprint.kt
@@ -28,8 +28,8 @@ abstract class AbstractModuleBlueprint(val name: String,
                                    val generateTests : Boolean) {
 
     val moduleRoot = root.joinPath(name)
-    val moduleDependencies = dependencies.filterIsInstance<ModuleDependency>()
-    private val methodsToCallWithIn = moduleDependencies.map { it.methodToCall }
+    val moduleDependencies by lazy{ dependencies.filterIsInstance<ModuleDependency>()}
+    private val methodsToCallWithIn by lazy { moduleDependencies.map { it.methodToCall } }
 
     val packagesBlueprint by lazy {
         PackagesBlueprint(javaPackageCount, javaClassCount, javaMethodsPerClass, kotlinPackageCount,

--- a/src/main/kotlin/com/google/androidstudiopoet/models/AndroidModuleBlueprint.kt
+++ b/src/main/kotlin/com/google/androidstudiopoet/models/AndroidModuleBlueprint.kt
@@ -45,10 +45,12 @@ class AndroidModuleBlueprint(name: String,
     val codePath = mainPath.joinPath("java")
     val packagePath = codePath.joinPaths(packageName.split("."))
 
-    private val resourcesToReferWithin = dependencies
-            .filterIsInstance<AndroidModuleDependency>()
-            .map { it.resourcesToRefer }
-            .fold(ResourcesToRefer(listOf(), listOf(), listOf())) { acc, resourcesToRefer -> resourcesToRefer.combine(acc) }
+    private val resourcesToReferWithin by lazy {
+        dependencies
+                .filterIsInstance<AndroidModuleDependency>()
+                .map { it.resourcesToRefer }
+                .fold(ResourcesToRefer(listOf(), listOf(), listOf())) { acc, resourcesToRefer -> resourcesToRefer.combine(acc) }
+    }
 
     val resourcesBlueprint by lazy {
         when (resourcesConfig) {

--- a/src/main/kotlin/com/google/androidstudiopoet/models/Dependencies.kt
+++ b/src/main/kotlin/com/google/androidstudiopoet/models/Dependencies.kt
@@ -24,5 +24,3 @@ class AndroidModuleDependency(name: String, methodToCall: MethodToCall, method: 
 data class LibraryDependency(val method: String, val name: String) : Dependency
 
 interface Dependency
-
-const val DEFAULT_DEPENDENCY_METHOD = "implementation"

--- a/src/main/kotlin/com/google/androidstudiopoet/models/FromToDependencyConfig.kt
+++ b/src/main/kotlin/com/google/androidstudiopoet/models/FromToDependencyConfig.kt
@@ -16,4 +16,4 @@ limitations under the License.
 
 package com.google.androidstudiopoet.models
 
-data class FromToDependencyConfig(val from: String, val to: String)
+data class FromToDependencyConfig(val from: String, val to: String, val method: String)

--- a/src/main/kotlin/com/google/androidstudiopoet/models/FromToDependencyConfig.kt
+++ b/src/main/kotlin/com/google/androidstudiopoet/models/FromToDependencyConfig.kt
@@ -16,4 +16,4 @@ limitations under the License.
 
 package com.google.androidstudiopoet.models
 
-data class FromToDependencyConfig(val from: String, val to: String, val method: String)
+data class FromToDependencyConfig(val from: String, val to: String, val method: String? = null)

--- a/src/main/kotlin/com/google/androidstudiopoet/models/Topologies.kt
+++ b/src/main/kotlin/com/google/androidstudiopoet/models/Topologies.kt
@@ -16,6 +16,7 @@ limitations under the License.
 
 package com.google.androidstudiopoet.models
 
+import com.google.androidstudiopoet.DEFAULT_DEPENDENCY_METHOD
 import com.google.androidstudiopoet.input.ConfigPOJO
 import java.security.InvalidParameterException
 import java.util.*
@@ -26,6 +27,7 @@ import java.util.*
 enum class Topologies {
     FULL {
         override fun generateDependencies(parameters: Map<String, String>, configPOJO: ConfigPOJO): List<FromToDependencyConfig> {
+            val method = getMethod(parameters)
             val random = randomWithSeed(parameters)
             val density = getDensity(parameters)
             val result = mutableListOf<FromToDependencyConfig>()
@@ -34,7 +36,7 @@ enum class Topologies {
                 val fromName = allNames[from]
                 for (to in from + 1 until allNames.size) {
                     if (random.nextFloat() < density) {
-                        result.add(FromToDependencyConfig(fromName, allNames[to]))
+                        result.add(FromToDependencyConfig(fromName, allNames[to], method))
                     }
                 }
             }
@@ -44,6 +46,7 @@ enum class Topologies {
 
     CONNECTED {
         override fun generateDependencies(parameters: Map<String, String>, configPOJO: ConfigPOJO): List<FromToDependencyConfig> {
+            val method = getMethod(parameters)
             val random = randomWithSeed(parameters)
             val density = getDensity(parameters)
             val result = mutableListOf<FromToDependencyConfig>()
@@ -54,7 +57,7 @@ enum class Topologies {
                 val toName = allNames[to]
                 for (from in 0 until to) {
                     if (random.nextFloat() < density) {
-                        result.add(FromToDependencyConfig(allNames[from], toName))
+                        result.add(FromToDependencyConfig(allNames[from], toName, method))
                         numFrom++
                     }
                 }
@@ -68,13 +71,14 @@ enum class Topologies {
 
     LINEAR {
         override fun generateDependencies(parameters: Map<String, String>, configPOJO: ConfigPOJO): List<FromToDependencyConfig> {
+            val method = getMethod(parameters)
             val allNames = generateModuleNames(configPOJO)
             val random = randomWithSeed(parameters)
             val density = getDensity(parameters)
             val result = mutableListOf<FromToDependencyConfig>()
             for (id in 1 until allNames.size) {
                 if (random.nextFloat() < density) {
-                    result.add(FromToDependencyConfig(allNames[id - 1], allNames[id]))
+                    result.add(FromToDependencyConfig(allNames[id - 1], allNames[id], method))
                 }
             }
             return result
@@ -83,13 +87,14 @@ enum class Topologies {
 
     STAR {
         override fun generateDependencies(parameters: Map<String, String>, configPOJO: ConfigPOJO): List<FromToDependencyConfig> {
+            val method = getMethod(parameters)
             val allNames = generateModuleNames(configPOJO)
             val random = randomWithSeed(parameters)
             val density = getDensity(parameters)
             val result = mutableListOf<FromToDependencyConfig>()
             for (id in 1 until allNames.size) {
                 if (random.nextFloat() < density) {
-                    result.add(FromToDependencyConfig(allNames[0], allNames[id]))
+                    result.add(FromToDependencyConfig(allNames[0], allNames[id], method))
                 }
             }
             return result
@@ -100,6 +105,7 @@ enum class Topologies {
         private fun getParent(node: Int, degree: Int) = (node - 1) / degree
 
         override fun generateDependencies(parameters: Map<String, String>, configPOJO: ConfigPOJO): List<FromToDependencyConfig> {
+            val method = getMethod(parameters)
             val allNames = generateModuleNames(configPOJO)
             val degree: Int = parameters["degree"]?.toInt() ?: throw InvalidParameterException("No degree was specified: $parameters")
             if (degree < 1) {
@@ -110,7 +116,7 @@ enum class Topologies {
             val result = mutableListOf<FromToDependencyConfig>()
             for (id in 1 until allNames.size) {
                 if (random.nextFloat() < density) {
-                    result.add(FromToDependencyConfig(allNames[getParent(id, degree)], allNames[id]))
+                    result.add(FromToDependencyConfig(allNames[getParent(id, degree)], allNames[id], method))
                 }
             }
             return result
@@ -119,6 +125,7 @@ enum class Topologies {
 
     VARIABLE_TREE {
         override fun generateDependencies(parameters: Map<String, String>, configPOJO: ConfigPOJO): List<FromToDependencyConfig> {
+            val method = getMethod(parameters)
             val allNames = generateModuleNames(configPOJO)
             val random = randomWithSeed(parameters)
             val wideness = getWideness(parameters)
@@ -130,7 +137,7 @@ enum class Topologies {
             var currentParent = 0
             for (to in 1 until allNames.size) {
                 if (random.nextFloat() < density) {
-                    result.add(FromToDependencyConfig(allNames[currentParent], allNames[to]))
+                    result.add(FromToDependencyConfig(allNames[currentParent], allNames[to], method))
                 }
                 if (random.nextFloat() >= wideness) {
                     currentParent++
@@ -142,6 +149,7 @@ enum class Topologies {
 
     RECTANGLE {
         override fun generateDependencies(parameters: Map<String, String>, configPOJO: ConfigPOJO): List<FromToDependencyConfig> {
+            val method = getMethod(parameters)
             val width: Int = parameters["width"]?.toInt() ?: throw InvalidParameterException("width was not specified: $parameters")
             if (width <= 0) {
                 throw InvalidParameterException("width must be greater than 0: $parameters")
@@ -155,7 +163,7 @@ enum class Topologies {
                 val base = ((to / width) - 1) * width
                 for (from in 0 until width) {
                     if (random.nextFloat() < density) {
-                        result.add(FromToDependencyConfig(allNames[base + from], allNames[to]))
+                        result.add(FromToDependencyConfig(allNames[base + from], allNames[to], method))
                     }
                 }
             }
@@ -165,6 +173,7 @@ enum class Topologies {
 
     CONNECTED_RECTANGLE {
         override fun generateDependencies(parameters: Map<String, String>, configPOJO: ConfigPOJO): List<FromToDependencyConfig> {
+            val method = getMethod(parameters)
             val width: Int = parameters["width"]?.toInt() ?: throw InvalidParameterException("width was not specified: $parameters")
             if (width <= 0) {
                 throw InvalidParameterException("width must be greater than 0: $parameters")
@@ -180,7 +189,7 @@ enum class Topologies {
                 var numFrom = 0
                 for (from in 0 until width) {
                     if (random.nextFloat() < density) {
-                        result.add(FromToDependencyConfig(allNames[base + from], allNames[to]))
+                        result.add(FromToDependencyConfig(allNames[base + from], allNames[to], method))
                         numFrom++
                     }
                 }
@@ -212,6 +221,8 @@ enum class Topologies {
     protected fun getDensity(parameters: Map<String, String>, default: Float = 1.0f) = parameters["density"]?.toFloat() ?: default
 
     protected fun getWideness(parameters: Map<String, String>, default: Float = 0.5f) = parameters["wideness"]?.toFloat() ?: default
+
+    protected fun getMethod(parameters: Map<String, String>) = parameters.getOrDefault("method", DEFAULT_DEPENDENCY_METHOD)
 
     /**
      * Function that should add dependencies to configPOJO based on the given parameters and the

--- a/src/main/kotlin/com/google/androidstudiopoet/models/Topologies.kt
+++ b/src/main/kotlin/com/google/androidstudiopoet/models/Topologies.kt
@@ -222,7 +222,7 @@ enum class Topologies {
 
     protected fun getWideness(parameters: Map<String, String>, default: Float = 0.5f) = parameters["wideness"]?.toFloat() ?: default
 
-    protected fun getMethod(parameters: Map<String, String>) = parameters.getOrDefault("method", DEFAULT_DEPENDENCY_METHOD)
+    protected fun getMethod(parameters: Map<String, String>) = parameters["method"]
 
     /**
      * Function that should add dependencies to configPOJO based on the given parameters and the

--- a/src/test/kotlin/com/google/androidstudiopoet/DependencyValidatorTest.kt
+++ b/src/test/kotlin/com/google/androidstudiopoet/DependencyValidatorTest.kt
@@ -29,7 +29,7 @@ class DependencyValidatorTest {
     fun `isValid returns true when dependencies field are smaller then numModules`() {
         val moduleCount = 4
         val androidModuleCount = 0
-        val dependencies = listOf(FromToDependencyConfig("module1", "module2"))
+        val dependencies = listOf(FromToDependencyConfig("module1", "module2", DEFAULT_DEPENDENCY_METHOD))
         assertTrue(validator.isValid(dependencies, moduleCount,androidModuleCount))
     }
 
@@ -37,7 +37,7 @@ class DependencyValidatorTest {
     fun `isValid returns false when Dependency#to is bigger then numModules`() {
         val moduleCount = 2
         val androidModuleCount = 0
-        val dependencies = listOf(FromToDependencyConfig("module1", "module2"))
+        val dependencies = listOf(FromToDependencyConfig("module1", "module2", DEFAULT_DEPENDENCY_METHOD))
         assertFalse(validator.isValid(dependencies, moduleCount, androidModuleCount))
     }
 
@@ -45,7 +45,7 @@ class DependencyValidatorTest {
     fun `isValid returns false when Dependency#from is bigger then numModules`() {
         val moduleCount = 2
         val androidModuleCount = 0
-        val dependencies = listOf(FromToDependencyConfig("module2", "module1"))
+        val dependencies = listOf(FromToDependencyConfig("module2", "module1", DEFAULT_DEPENDENCY_METHOD))
         assertFalse(validator.isValid(dependencies, moduleCount, androidModuleCount))
     }
 
@@ -53,7 +53,7 @@ class DependencyValidatorTest {
     fun `isValid returns true when dependencies field are smaller then androidModules`() {
         val moduleCount = 0
         val androidModuleCount = 4
-        val dependencies = listOf(FromToDependencyConfig("androidAppModule1", "androidAppModule2"))
+        val dependencies = listOf(FromToDependencyConfig("androidAppModule1", "androidAppModule2", DEFAULT_DEPENDENCY_METHOD))
         assertTrue(validator.isValid(dependencies, moduleCount,androidModuleCount))
     }
 
@@ -61,7 +61,7 @@ class DependencyValidatorTest {
     fun `isValid returns false when Dependency#to is bigger then androidModules`() {
         val moduleCount = 0
         val androidModuleCount = 2
-        val dependencies = listOf(FromToDependencyConfig("androidAppModule1", "androidAppModule2"))
+        val dependencies = listOf(FromToDependencyConfig("androidAppModule1", "androidAppModule2", DEFAULT_DEPENDENCY_METHOD))
         assertFalse(validator.isValid(dependencies, moduleCount, androidModuleCount))
     }
 
@@ -69,7 +69,7 @@ class DependencyValidatorTest {
     fun `isValid returns false when Dependency#from is bigger then androidModules`() {
         val moduleCount = 2
         val androidModuleCount = 2
-        val dependencies = listOf(FromToDependencyConfig("androidAppModule2", "androidAppModule1"))
+        val dependencies = listOf(FromToDependencyConfig("androidAppModule2", "androidAppModule1", DEFAULT_DEPENDENCY_METHOD))
         assertFalse(validator.isValid(dependencies, moduleCount, androidModuleCount))
     }
 
@@ -77,7 +77,7 @@ class DependencyValidatorTest {
     fun `isValid returns false when Dependency#from is module and to is Android`() {
         val moduleCount = 2
         val androidModuleCount = 2
-        val dependencies = listOf(FromToDependencyConfig("module1", "androidAppModule1"))
+        val dependencies = listOf(FromToDependencyConfig("module1", "androidAppModule1", DEFAULT_DEPENDENCY_METHOD))
         assertFalse(validator.isValid(dependencies, moduleCount, androidModuleCount))
     }
 
@@ -85,7 +85,7 @@ class DependencyValidatorTest {
     fun `isValid returns false when Dependency#to is App`() {
         val moduleCount = 2
         val androidModuleCount = 2
-        val dependencies = listOf(FromToDependencyConfig("androidAppModule1", "androidAppModule0"))
+        val dependencies = listOf(FromToDependencyConfig("androidAppModule1", "androidAppModule0", DEFAULT_DEPENDENCY_METHOD))
         assertFalse(validator.isValid(dependencies, moduleCount, androidModuleCount))
     }
 
@@ -93,7 +93,7 @@ class DependencyValidatorTest {
     fun `isValid returns false when Dependency#from type is invalid`() {
         val moduleCount = 2
         val androidModuleCount = 2
-        val dependencies = listOf(FromToDependencyConfig("invalid0", "androidAppModule0"))
+        val dependencies = listOf(FromToDependencyConfig("invalid0", "androidAppModule0", DEFAULT_DEPENDENCY_METHOD))
         assertFalse(validator.isValid(dependencies, moduleCount, androidModuleCount))
     }
 
@@ -101,7 +101,7 @@ class DependencyValidatorTest {
     fun `isValid returns false when Dependency#to type is invalid`() {
         val moduleCount = 2
         val androidModuleCount = 2
-        val dependencies = listOf(FromToDependencyConfig("module0", "invalid0"))
+        val dependencies = listOf(FromToDependencyConfig("module0", "invalid0", DEFAULT_DEPENDENCY_METHOD))
         assertFalse(validator.isValid(dependencies, moduleCount, androidModuleCount))
     }
 }

--- a/src/test/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToAndroidModuleConfigConverterTest.kt
+++ b/src/test/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToAndroidModuleConfigConverterTest.kt
@@ -16,7 +16,6 @@ limitations under the License.
 
 package com.google.androidstudiopoet.converters
 
-import com.google.androidstudiopoet.DEFAULT_DEPENDENCY_METHOD
 import com.google.androidstudiopoet.input.*
 import com.google.androidstudiopoet.models.FromToDependencyConfig
 import com.google.androidstudiopoet.testutils.*
@@ -41,9 +40,10 @@ private const val ANDROID_MODULE_NAME_0 = "androidAppModule0"
 private const val ANDROID_MODULE_NAME_1 = "androidAppModule1"
 private const val MODULE_NAME_0 = "module0"
 private const val MODULE_NAME_1 = "module1"
+private const val DEPENDENCY_METHOD = "api"
 
 private val PURE_MODULE_LIST = listOf(MODULE_NAME_0, MODULE_NAME_1)
-private val PURE_MODULE_DEPENDENCY_LIST = PURE_MODULE_LIST.map { DependencyConfig.ModuleDependencyConfig(it, DEFAULT_DEPENDENCY_METHOD) }
+private val PURE_MODULE_DEPENDENCY_LIST = PURE_MODULE_LIST.map { DependencyConfig.ModuleDependencyConfig(it, DEPENDENCY_METHOD) }
 
 class ConfigPojoToAndroidModuleConfigConverterTest {
 
@@ -68,11 +68,11 @@ class ConfigPojoToAndroidModuleConfigConverterTest {
 
         generateTests = GENERATE_TESTS
         androidModules = ANDROID_MODULE_COUNT
-        dependencies = listOf(FromToDependencyConfig(ANDROID_MODULE_NAME_0, MODULE_NAME_0, DEFAULT_DEPENDENCY_METHOD),
-                FromToDependencyConfig(ANDROID_MODULE_NAME_0, MODULE_NAME_1, DEFAULT_DEPENDENCY_METHOD),
-                FromToDependencyConfig(ANDROID_MODULE_NAME_1, MODULE_NAME_0, DEFAULT_DEPENDENCY_METHOD),
-                FromToDependencyConfig(ANDROID_MODULE_NAME_1, MODULE_NAME_1, DEFAULT_DEPENDENCY_METHOD),
-                FromToDependencyConfig(ANDROID_MODULE_NAME_0, ANDROID_MODULE_NAME_1, DEFAULT_DEPENDENCY_METHOD))
+        dependencies = listOf(FromToDependencyConfig(ANDROID_MODULE_NAME_0, MODULE_NAME_0, DEPENDENCY_METHOD),
+                FromToDependencyConfig(ANDROID_MODULE_NAME_0, MODULE_NAME_1, DEPENDENCY_METHOD),
+                FromToDependencyConfig(ANDROID_MODULE_NAME_1, MODULE_NAME_0, DEPENDENCY_METHOD),
+                FromToDependencyConfig(ANDROID_MODULE_NAME_1, MODULE_NAME_1, DEPENDENCY_METHOD),
+                FromToDependencyConfig(ANDROID_MODULE_NAME_0, ANDROID_MODULE_NAME_1, DEPENDENCY_METHOD))
     }
 
     private val converter = ConfigPojoToAndroidModuleConfigConverter()
@@ -106,7 +106,7 @@ class ConfigPojoToAndroidModuleConfigConverterTest {
         val androidModuleConfig = converter.convert(configPOJO, 0, productFlavorConfigs, buildTypes)
         assertOn(androidModuleConfig) {
             hasLaunchActivity.assertTrue()
-            dependencies!!.assertEquals(listOf(DependencyConfig.ModuleDependencyConfig(ANDROID_MODULE_NAME_1, DEFAULT_DEPENDENCY_METHOD)) + PURE_MODULE_DEPENDENCY_LIST)
+            dependencies!!.assertEquals(listOf(DependencyConfig.ModuleDependencyConfig(ANDROID_MODULE_NAME_1, DEPENDENCY_METHOD)) + PURE_MODULE_DEPENDENCY_LIST)
             resourcesConfig!!.assertEquals(ResourcesConfig(ACTIVITY_COUNT + 2, ACTIVITY_COUNT + 5, ACTIVITY_COUNT))
         }
     }

--- a/src/test/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToAndroidModuleConfigConverterTest.kt
+++ b/src/test/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToAndroidModuleConfigConverterTest.kt
@@ -16,6 +16,7 @@ limitations under the License.
 
 package com.google.androidstudiopoet.converters
 
+import com.google.androidstudiopoet.DEFAULT_DEPENDENCY_METHOD
 import com.google.androidstudiopoet.input.*
 import com.google.androidstudiopoet.models.FromToDependencyConfig
 import com.google.androidstudiopoet.testutils.*
@@ -42,7 +43,7 @@ private const val MODULE_NAME_0 = "module0"
 private const val MODULE_NAME_1 = "module1"
 
 private val PURE_MODULE_LIST = listOf(MODULE_NAME_0, MODULE_NAME_1)
-private val PURE_MODULE_DEPENDENCY_LIST = PURE_MODULE_LIST.map { DependencyConfig.ModuleDependencyConfig(it) }
+private val PURE_MODULE_DEPENDENCY_LIST = PURE_MODULE_LIST.map { DependencyConfig.ModuleDependencyConfig(it, DEFAULT_DEPENDENCY_METHOD) }
 
 class ConfigPojoToAndroidModuleConfigConverterTest {
 
@@ -67,11 +68,11 @@ class ConfigPojoToAndroidModuleConfigConverterTest {
 
         generateTests = GENERATE_TESTS
         androidModules = ANDROID_MODULE_COUNT
-        dependencies = listOf(FromToDependencyConfig(ANDROID_MODULE_NAME_0, MODULE_NAME_0),
-                FromToDependencyConfig(ANDROID_MODULE_NAME_0, MODULE_NAME_1),
-                FromToDependencyConfig(ANDROID_MODULE_NAME_1, MODULE_NAME_0),
-                FromToDependencyConfig(ANDROID_MODULE_NAME_1, MODULE_NAME_1),
-                FromToDependencyConfig(ANDROID_MODULE_NAME_0, ANDROID_MODULE_NAME_1))
+        dependencies = listOf(FromToDependencyConfig(ANDROID_MODULE_NAME_0, MODULE_NAME_0, DEFAULT_DEPENDENCY_METHOD),
+                FromToDependencyConfig(ANDROID_MODULE_NAME_0, MODULE_NAME_1, DEFAULT_DEPENDENCY_METHOD),
+                FromToDependencyConfig(ANDROID_MODULE_NAME_1, MODULE_NAME_0, DEFAULT_DEPENDENCY_METHOD),
+                FromToDependencyConfig(ANDROID_MODULE_NAME_1, MODULE_NAME_1, DEFAULT_DEPENDENCY_METHOD),
+                FromToDependencyConfig(ANDROID_MODULE_NAME_0, ANDROID_MODULE_NAME_1, DEFAULT_DEPENDENCY_METHOD))
     }
 
     private val converter = ConfigPojoToAndroidModuleConfigConverter()
@@ -105,7 +106,7 @@ class ConfigPojoToAndroidModuleConfigConverterTest {
         val androidModuleConfig = converter.convert(configPOJO, 0, productFlavorConfigs, buildTypes)
         assertOn(androidModuleConfig) {
             hasLaunchActivity.assertTrue()
-            dependencies!!.assertEquals(listOf(DependencyConfig.ModuleDependencyConfig(ANDROID_MODULE_NAME_1)) + PURE_MODULE_DEPENDENCY_LIST)
+            dependencies!!.assertEquals(listOf(DependencyConfig.ModuleDependencyConfig(ANDROID_MODULE_NAME_1, DEFAULT_DEPENDENCY_METHOD)) + PURE_MODULE_DEPENDENCY_LIST)
             resourcesConfig!!.assertEquals(ResourcesConfig(ACTIVITY_COUNT + 2, ACTIVITY_COUNT + 5, ACTIVITY_COUNT))
         }
     }

--- a/src/test/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToModuleConfigConverterTest.kt
+++ b/src/test/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToModuleConfigConverterTest.kt
@@ -17,6 +17,8 @@ limitations under the License.
 package com.google.androidstudiopoet.converters
 
 import com.google.androidstudiopoet.input.ConfigPOJO
+import com.google.androidstudiopoet.input.DependencyConfig
+import com.google.androidstudiopoet.models.FromToDependencyConfig
 import com.google.androidstudiopoet.testutils.assertEquals
 import com.google.androidstudiopoet.testutils.assertOn
 import com.google.androidstudiopoet.testutils.mock
@@ -34,6 +36,14 @@ private const val KOTLIN_PACKAGE_COUNT = 8
 private const val KOTLIN_CLASS_COUNT = 9
 
 private const val GENERATE_TESTS = true
+
+private const val MODULE_NAME_0 = "module0"
+private const val MODULE_NAME_1 = "module1"
+private const val MODULE_NAME_3 = "module3"
+private const val METHOD_3_0 = "method30"
+private const val METHOD_3_1 = "method31"
+private val DEPENDENCY_LIST = listOf(DependencyConfig.ModuleDependencyConfig(MODULE_NAME_0, METHOD_3_0),
+        DependencyConfig.ModuleDependencyConfig(MODULE_NAME_1, METHOD_3_1))
 
 class ConfigPojoToModuleConfigConverterTest {
     private val index = 3
@@ -56,14 +66,17 @@ class ConfigPojoToModuleConfigConverterTest {
 
         generateTests = GENERATE_TESTS
 
+        dependencies = listOf(FromToDependencyConfig(MODULE_NAME_3, MODULE_NAME_0, METHOD_3_0),
+                FromToDependencyConfig(MODULE_NAME_3, MODULE_NAME_1, METHOD_3_1))
+
     }
 
     private val converter = ConfigPojoToModuleConfigConverter()
 
     @Test
     fun `convert passes correct values to result ModuleConfig`() {
-        val androidModuleConfig = converter.convert(configPOJO, index)
-        assertOn(androidModuleConfig) {
+        val moduleConfig = converter.convert(configPOJO, index)
+        assertOn(moduleConfig) {
             javaClassCount.assertEquals(JAVA_CLASS_COUNT)
             javaPackageCount.assertEquals(JAVA_PACKAGE_COUNT)
             javaMethodsPerClass.assertEquals(configPOJO.javaMethodsPerClass)
@@ -76,6 +89,7 @@ class ConfigPojoToModuleConfigConverterTest {
 
             extraLines!!.assertEquals(extraLinesForBuildFile)
             generateTests.assertEquals(GENERATE_TESTS)
+            dependencies!!.assertEquals(DEPENDENCY_LIST)
         }
     }
 

--- a/src/test/kotlin/com/google/androidstudiopoet/models/DependencyTest.kt
+++ b/src/test/kotlin/com/google/androidstudiopoet/models/DependencyTest.kt
@@ -25,9 +25,10 @@ import org.junit.Test
 class DependencyTest {
     @Test
     fun `Dependency deserialized correctly`() {
-        @Language("JSON") val dependencyString = "{\n  \"from\": \"module2\",\n  \"to\": \"module1\"\n}"
+        @Language("JSON") val dependencyString = "{\n  \"from\": \"module2\",\n  \"to\": \"module1\",\n  \"method\": \"api\"\n}"
         val dependency = Gson().fromJson(dependencyString, FromToDependencyConfig::class.java)
         assertEquals("module2", dependency.from)
         assertEquals("module1", dependency.to)
+        assertEquals("api", dependency.method)
     }
 }


### PR DESCRIPTION
- Add a method field in FromToDependencyConfig
- Cache temporal blueprints that simplifies code when generating
bluprints and allows to have multiple dependency methods (this was a
bug).