### PR TITLE
Fixed problem with generation for compact format

### DIFF
--- a/src/main/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToModuleConfigConverter.kt
+++ b/src/main/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToModuleConfigConverter.kt
@@ -16,6 +16,7 @@ limitations under the License.
 
 package com.google.androidstudiopoet.converters
 
+import com.google.androidstudiopoet.input.CodeConfig
 import com.google.androidstudiopoet.input.ModuleConfig
 import com.google.androidstudiopoet.input.ConfigPOJO
 import com.google.androidstudiopoet.input.DependencyConfig
@@ -23,21 +24,26 @@ import com.google.androidstudiopoet.input.DependencyConfig
 class ConfigPojoToModuleConfigConverter {
     fun convert(config: ConfigPOJO, index: Int): ModuleConfig {
         return ModuleConfig().apply {
-             javaPackageCount = config.javaPackageCount!!.toInt()
-             javaClassCount = config.javaClassCount!!.toInt()
-             javaMethodsPerClass = config.javaMethodsPerClass
+            java = CodeConfig().apply {
+                packages = config.javaPackageCount!!.toInt()
+                classesPerPackage = config.javaClassCount!!.toInt()
+                methodsPerClass = config.javaMethodsPerClass
+            }
 
-             kotlinPackageCount = config.kotlinPackageCount!!.toInt()
-             kotlinClassCount = config.kotlinClassCount!!.toInt()
-             kotlinMethodsPerClass = config.kotlinMethodsPerClass
-             useKotlin = config.useKotlin
+            kotlin = CodeConfig().apply {
+                packages = config.kotlinPackageCount!!.toInt()
+                classesPerPackage = config.kotlinClassCount!!.toInt()
+                methodsPerClass = config.kotlinMethodsPerClass
+            }
 
-             extraLines = config.extraBuildFileLines
+            useKotlin = config.useKotlin
 
-             generateTests = config.generateTests
+            extraLines = config.extraBuildFileLines
 
-             moduleName = config.getModuleName(index)
-             dependencies = config.resolvedDependencies[moduleName]?.map {  DependencyConfig.ModuleDependencyConfig(it.to, it.method) } ?: listOf()
+            generateTests = config.generateTests
+
+            moduleName = config.getModuleName(index)
+            dependencies = config.resolvedDependencies[moduleName]?.map { DependencyConfig.ModuleDependencyConfig(it.to, it.method) } ?: listOf()
         }
     }
 }

--- a/src/main/kotlin/com/google/androidstudiopoet/input/ModuleConfig.kt
+++ b/src/main/kotlin/com/google/androidstudiopoet/input/ModuleConfig.kt
@@ -20,12 +20,6 @@ open class ModuleConfig {
     lateinit var moduleName: String
     var java: CodeConfig? = null
     var kotlin: CodeConfig? = null
-    var javaPackageCount: Int = 0
-    var javaClassCount: Int = 0
-    var javaMethodsPerClass: Int = 0
-    var kotlinPackageCount: Int = 0
-    var kotlinClassCount: Int = 0
-    var kotlinMethodsPerClass: Int = 0
     var useKotlin: Boolean = false
     var extraLines: List<String>? = null
     var dependencies: List<DependencyConfig>? = null

--- a/src/main/kotlin/com/google/androidstudiopoet/models/PackagesBlueprint.kt
+++ b/src/main/kotlin/com/google/androidstudiopoet/models/PackagesBlueprint.kt
@@ -58,17 +58,10 @@ data class PackagesBlueprint(private val javaConfig: CodeConfig?,
             previousClassMethodToCall = listOf(packageBlueprint.methodToCallFromOutside)
         }
 
-        methodToCallFromOutside = MethodToCall("", "")
-
-        if (kotlinPackageCount != 0) {
-            if (!kotlinPackageBlueprints.isEmpty()) {
-                methodToCallFromOutside = kotlinPackageBlueprints.last().methodToCallFromOutside
-            }
-
+        methodToCallFromOutside = if (kotlinPackageCount != 0) {
+            kotlinPackageBlueprints.last().methodToCallFromOutside
         } else {
-            if (!javaPackageBlueprints.isEmpty()) {
-                methodToCallFromOutside = javaPackageBlueprints.last().methodToCallFromOutside
-            }
+            javaPackageBlueprints.last().methodToCallFromOutside
         }
     }
 

--- a/src/test/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToModuleConfigConverterTest.kt
+++ b/src/test/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToModuleConfigConverterTest.kt
@@ -77,13 +77,17 @@ class ConfigPojoToModuleConfigConverterTest {
     fun `convert passes correct values to result ModuleConfig`() {
         val moduleConfig = converter.convert(configPOJO, index)
         assertOn(moduleConfig) {
-            javaClassCount.assertEquals(JAVA_CLASS_COUNT)
-            javaPackageCount.assertEquals(JAVA_PACKAGE_COUNT)
-            javaMethodsPerClass.assertEquals(configPOJO.javaMethodsPerClass)
+            assertOn(java!!) {
+                packages.assertEquals(JAVA_PACKAGE_COUNT)
+                classesPerPackage.assertEquals(JAVA_CLASS_COUNT)
+                methodsPerClass.assertEquals(configPOJO.javaMethodsPerClass)
+            }
 
-            kotlinPackageCount.assertEquals(KOTLIN_PACKAGE_COUNT)
-            kotlinClassCount.assertEquals(KOTLIN_CLASS_COUNT)
-            kotlinMethodsPerClass.assertEquals(configPOJO.kotlinMethodsPerClass)
+            assertOn(kotlin!!) {
+                packages.assertEquals(KOTLIN_PACKAGE_COUNT)
+                classesPerPackage.assertEquals(KOTLIN_CLASS_COUNT)
+                methodsPerClass.assertEquals(configPOJO.kotlinMethodsPerClass)
+            }
 
             useKotlin.assertEquals(configPOJO.useKotlin)
 


### PR DESCRIPTION
`ModuleConfig` was still relying on old field for classes, packages and
methods