### PR TITLE
Refactor module generators to check for optional buildBazelBlueprint

### DIFF
--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/SourceModuleGenerator.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/SourceModuleGenerator.kt
@@ -100,8 +100,8 @@ class SourceModuleGenerator(private val moduleBuildGradleGenerator: ModuleBuildG
         writeLibsFolder(moduleRootFile)
         moduleBuildGradleGenerator.generate(moduleBlueprint.buildGradleBlueprint)
 
-        if (moduleBlueprint.generateBazelFiles != null && moduleBlueprint.generateBazelFiles) {
-          moduleBuildBazelGenerator.generate(moduleBlueprint.buildBazelBlueprint)
+        moduleBlueprint.buildBazelBlueprint?.let {
+            moduleBuildBazelGenerator.generate(it)
         }
 
         packagesGenerator.writePackages(moduleBlueprint.packagesBlueprint)

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/android_modules/AndroidModuleGenerator.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/android_modules/AndroidModuleGenerator.kt
@@ -45,8 +45,8 @@ class AndroidModuleGenerator(private val resourcesGenerator: ResourcesGenerator,
         blueprint.activityBlueprints.forEach({ activityGenerator.generate(it) })
         manifestGenerator.generate(blueprint)
 
-        if (blueprint.generateBazelFiles != null && blueprint.generateBazelFiles) {
-            buildBazelGenerator.generate(blueprint.buildBazelBlueprint)
+        blueprint.buildBazelBlueprint?.let {
+            buildBazelGenerator.generate(it)
         }
     }
 

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/AbstractModuleBlueprint.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/AbstractModuleBlueprint.kt
@@ -26,8 +26,7 @@ abstract class AbstractModuleBlueprint(val name: String,
                                        javaConfig: CodeConfig?,
                                        kotlinConfig: CodeConfig?,
                                        val extraLines: List<String>?,
-                                       val generateTests : Boolean,
-                                       val generateBazelFiles: Boolean? = false) {
+                                       val generateTests : Boolean) {
 
     val moduleRoot = root.joinPath(name)
     val moduleDependencies by lazy{ dependencies.filterIsInstance<ModuleDependency>()}

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/AndroidModuleBlueprint.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/AndroidModuleBlueprint.kt
@@ -37,7 +37,7 @@ class AndroidModuleBlueprint(name: String,
                              pluginConfigs: List<PluginConfig>?,
                              generateBazelFiles: Boolean?
 ) : AbstractModuleBlueprint(name, projectRoot, useKotlin, dependencies, javaConfig, kotlinConfig, extraLines,
-        generateTests, generateBazelFiles) {
+        generateTests) {
 
     val packageName = "com.$name"
     val srcPath = moduleRoot.joinPath("src")
@@ -102,8 +102,11 @@ class AndroidModuleBlueprint(name: String,
                 packageName, extraLines, productFlavorConfigs, buildTypeConfigs, dependencies, pluginConfigs)
     }
 
-    val buildBazelBlueprint: AndroidBuildBazelBlueprint by lazy {
-        AndroidBuildBazelBlueprint(hasLaunchActivity, moduleRoot, packageName, dependencies, name)
+    val buildBazelBlueprint: AndroidBuildBazelBlueprint? by lazy {
+        when (generateBazelFiles) {
+            true -> AndroidBuildBazelBlueprint(hasLaunchActivity, moduleRoot, packageName, dependencies, name)
+            else -> null
+        }
     }
 
     private fun hasButterknifeDependency(): Boolean = buildGradleBlueprint.plugins

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/ModuleBlueprint.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/ModuleBlueprint.kt
@@ -30,7 +30,7 @@ class ModuleBlueprint(name: String,
                       pluginConfigs: List<PluginConfig>?,
                       generateBazelFiles: Boolean?)
     : AbstractModuleBlueprint(name, root, useKotlin, dependencies, javaConfig, kotlinConfig, extraLines,
-        generateTests, generateBazelFiles) {
+        generateTests) {
 
     val buildGradleBlueprint by lazy {
         ModuleBuildGradleBlueprint(dependencies.toSet(), useKotlin, generateTests, extraLines, moduleRoot,
@@ -38,6 +38,9 @@ class ModuleBlueprint(name: String,
     }
 
     val buildBazelBlueprint by lazy {
-        ModuleBuildBazelBlueprint(dependencies.toSet(), moduleRoot, name)
+        when (generateBazelFiles) {
+            true -> ModuleBuildBazelBlueprint(dependencies.toSet(), moduleRoot, name)
+            else -> null
+        }
     }
 }


### PR DESCRIPTION
.. so there's no need to know about generateBazelFiles.

Resolving @NikitaKozlov's comment at https://github.com/android/android-studio-poet/pull/133#discussion_r216986266