### PR TITLE
Add BazelLang.kt: a collection of data structures that represents a Bazel BUILD file.

### DIFF
--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/bazel/BazelLang.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/bazel/BazelLang.kt
@@ -1,0 +1,117 @@
+/*
+Copyright 2018 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.google.androidstudiopoet.generators.bazel
+
+/**
+ * Bazel uses the Starlark configuration language for BUILD files and .bzl extensions.
+ *
+ * https://docs.bazel.build/versions/master/skylark/language.html
+ */
+
+private const val BASE_INDENT = "    "
+
+interface Statement
+
+/**
+ * foo = "bar"
+ */
+data class AssignmentStatement(val lhs: String, val rhs: String) : Statement {
+    override fun toString() = """$lhs = $rhs"""
+}
+
+/**
+ * load("@foo//bar:baz.bzl", "symbol_foo", "symbol_bar")
+ */
+data class LoadStatement(val module: String, val symbols: List<String>) : Statement {
+    override fun toString() = """load("$module", ${symbols.map { "\"$it\"" }.joinToString(separator = ", ")})"""
+}
+
+/**
+ * # Comment foo bar baz
+ */
+data class Comment(val comment: String) {
+    override fun toString(): String =  """# $comment"""
+}
+
+/**
+ * A BUILD / BUILD.bazel target.
+ *
+ * A target is made of
+ *
+ * 1) a rule class.
+ * 2) mandatory "name" attribute.
+ * 3) other rule-specific attributes.
+ *
+ * e.g.
+ *
+ * android_library(
+ *     name = "lib_foo",
+ *     srcs = glob(["src/**/*.java"]),
+ *     deps = [":lib_bar"],
+ *     manifest = "AndroidManifest.xml",
+ *     custom_package = "com.example.foo",
+ *     resource_files = glob(["res/**/*"]),
+ * )
+ */
+data class Target(val ruleClass: String, val attributes: List<Attribute>) : Statement {
+    override fun toString() : String {
+        return when (attributes.size) {
+            0 -> "$ruleClass()"
+            else -> """$ruleClass(
+$BASE_INDENT${attributes.joinToString(separator = ",\n$BASE_INDENT") { it.toString() }}
+)"""
+        }
+    }
+}
+
+/**
+ * Data classes representing attributes in targets.
+ *
+ * To improve type safety, create data classes implementing Attribute, e.g. StringAttribute.
+ *
+ * Bazel supports the following attribute types:
+ *
+ * bool
+ * int
+ * int_list
+ * label
+ * label_keyed_string_dict
+ * label_list
+ * license
+ * output
+ * output_list
+ * string
+ * string_dict
+ * string_list
+ * string_list_dict
+ *
+ * List of attribute schemas from:
+ * https://docs.bazel.build/versions/master/skylark/lib/attr.html
+ */
+
+interface Attribute {
+    val name: String
+    val value: Any
+}
+
+data class RawAttribute(override val name: String, override val value: String): Attribute {
+    override fun toString() = """$name = $value"""
+}
+
+data class StringAttribute(override val name: String, override val value: String): Attribute {
+    override fun toString() = "$name = \"$value\""
+}

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/bazel/BazelLang.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/bazel/BazelLang.kt
@@ -58,13 +58,10 @@ data class Comment(val comment: String) {
  *
  * e.g.
  *
- * android_library(
+ * java_library(
  *     name = "lib_foo",
- *     srcs = glob(["src/**/*.java"]),
- *     deps = [":lib_bar"],
- *     manifest = "AndroidManifest.xml",
- *     custom_package = "com.example.foo",
- *     resource_files = glob(["res/**/*"]),
+ *     srcs = ["Foo.java", "Bar.java"],
+ *     deps = [":lib_baz"],
  * )
  */
 data class Target(val ruleClass: String, val attributes: List<Attribute>) : Statement {
@@ -72,7 +69,7 @@ data class Target(val ruleClass: String, val attributes: List<Attribute>) : Stat
         return when (attributes.size) {
             0 -> "$ruleClass()"
             else -> """$ruleClass(
-$BASE_INDENT${attributes.joinToString(separator = ",\n$BASE_INDENT") { it.toString() }}
+$BASE_INDENT${attributes.joinToString(separator = ",\n$BASE_INDENT") { it.toString() }},
 )"""
         }
     }

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/bazel/BazelLang.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/bazel/BazelLang.kt
@@ -19,6 +19,8 @@ package com.google.androidstudiopoet.generators.bazel
 /**
  * Bazel uses the Starlark configuration language for BUILD files and .bzl extensions.
  *
+ * Starlark is previously known as Skylark.
+ *
  * https://docs.bazel.build/versions/master/skylark/language.html
  */
 
@@ -106,7 +108,7 @@ interface Attribute {
 }
 
 data class RawAttribute(override val name: String, override val value: String): Attribute {
-    override fun toString() = """$name = $value"""
+    override fun toString() = "$name = $value"
 }
 
 data class StringAttribute(override val name: String, override val value: String): Attribute {

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/bazel/BazelLang.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/bazel/BazelLang.kt
@@ -26,19 +26,19 @@ package com.google.androidstudiopoet.generators.bazel
 
 private const val BASE_INDENT = "    "
 
-interface Statement
+sealed class Statement
 
 /**
  * foo = "bar"
  */
-data class AssignmentStatement(val lhs: String, val rhs: String) : Statement {
+data class AssignmentStatement(val lhs: String, val rhs: String) : Statement() {
     override fun toString() = """$lhs = $rhs"""
 }
 
 /**
  * load("@foo//bar:baz.bzl", "symbol_foo", "symbol_bar")
  */
-data class LoadStatement(val module: String, val symbols: List<String>) : Statement {
+data class LoadStatement(val module: String, val symbols: List<String>) : Statement() {
     override fun toString() = """load("$module", ${symbols.map { "\"$it\"" }.joinToString(separator = ", ")})"""
 }
 
@@ -66,7 +66,7 @@ data class Comment(val comment: String) {
  *     deps = [":lib_baz"],
  * )
  */
-data class Target(val ruleClass: String, val attributes: List<Attribute>) : Statement {
+data class Target(val ruleClass: String, val attributes: List<Attribute>) : Statement() {
     override fun toString() : String {
         return when (attributes.size) {
             0 -> "$ruleClass()"
@@ -102,15 +102,15 @@ $BASE_INDENT${attributes.joinToString(separator = ",\n$BASE_INDENT") { it.toStri
  * https://docs.bazel.build/versions/master/skylark/lib/attr.html
  */
 
-interface Attribute {
-    val name: String
-    val value: Any
+sealed class Attribute {
+    abstract val name: String
+    abstract val value: Any
 }
 
-data class RawAttribute(override val name: String, override val value: String): Attribute {
+data class RawAttribute(override val name: String, override val value: String): Attribute() {
     override fun toString() = "$name = $value"
 }
 
-data class StringAttribute(override val name: String, override val value: String): Attribute {
+data class StringAttribute(override val name: String, override val value: String): Attribute() {
     override fun toString() = "$name = \"$value\""
 }

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/BazelWorkspaceBlueprint.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/BazelWorkspaceBlueprint.kt
@@ -13,25 +13,28 @@
  */
 package com.google.androidstudiopoet.models
 
+import com.google.androidstudiopoet.generators.bazel.*
 import com.google.androidstudiopoet.utils.joinPath
 
 class BazelWorkspaceBlueprint(val projectRoot: String) {
 
   val workspacePath = projectRoot.joinPath("WORKSPACE")
 
-  val bazelWorkspaceContent = """android_sdk_repository(name = "androidsdk")
-# Google Maven Repository
-GMAVEN_TAG = "20180607-1"
+  val bazelWorkspaceContent = """${Target(
+      "android_sdk_repository",
+      listOf(StringAttribute("name", "androidsdk")))}
 
-http_archive(
-    name = "gmaven_rules",
-    strip_prefix = "gmaven_rules-%s" % GMAVEN_TAG,
-    urls = ["https://github.com/bazelbuild/gmaven_rules/archive/%s.tar.gz" % GMAVEN_TAG],
-)
-
-load("@gmaven_rules//:gmaven.bzl", "gmaven_rules")
-gmaven_rules()
+${Comment("Google Maven Repository")}
+${AssignmentStatement("GMAVEN_TAG", "\"20180607-1\"")}
+${Target(
+      "http_archive",
+      listOf(
+          StringAttribute("name", "gmaven_rules"),
+          RawAttribute("strip_prefix", "\"gmaven_rules-%s\" % GMAVEN_TAG"),
+          RawAttribute("urls", "[\"https://github.com/bazelbuild/gmaven_rules/archive/%s.tar.gz\" % GMAVEN_TAG]")
+      ))}
+${LoadStatement("@gmaven_rules//:gmaven.bzl", listOf("gmaven_rules") )}
+${Target("gmaven_rules", listOf())}
 """
 
 }
-

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/BazelWorkspaceBlueprint.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/BazelWorkspaceBlueprint.kt
@@ -33,7 +33,7 @@ ${Target(
           RawAttribute("strip_prefix", "\"gmaven_rules-%s\" % GMAVEN_TAG"),
           RawAttribute("urls", "[\"https://github.com/bazelbuild/gmaven_rules/archive/%s.tar.gz\" % GMAVEN_TAG]")
       ))}
-${LoadStatement("@gmaven_rules//:gmaven.bzl", listOf("gmaven_rules") )}
+${LoadStatement("@gmaven_rules//:gmaven.bzl", listOf("gmaven_rules"))}
 ${Target("gmaven_rules", listOf())}
 """
 

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/BazelWorkspaceBlueprint.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/BazelWorkspaceBlueprint.kt
@@ -20,21 +20,6 @@ class BazelWorkspaceBlueprint(val projectRoot: String) {
 
   val workspacePath = projectRoot.joinPath("WORKSPACE")
 
-  val bazelWorkspaceContent = """${Target(
-      "android_sdk_repository",
-      listOf(StringAttribute("name", "androidsdk")))}
-
-${Comment("Google Maven Repository")}
-${AssignmentStatement("GMAVEN_TAG", "\"20180607-1\"")}
-${Target(
-      "http_archive",
-      listOf(
-          StringAttribute("name", "gmaven_rules"),
-          RawAttribute("strip_prefix", "\"gmaven_rules-%s\" % GMAVEN_TAG"),
-          RawAttribute("urls", "[\"https://github.com/bazelbuild/gmaven_rules/archive/%s.tar.gz\" % GMAVEN_TAG]")
-      ))}
-${LoadStatement("@gmaven_rules//:gmaven.bzl", listOf("gmaven_rules"))}
-${Target("gmaven_rules", listOf())}
-"""
+  val gmavenRulesTag = "20180607-1"
 
 }

--- a/aspoet/src/test/kotlin/com/google/androidstudiopoet/generators/BazelWorkspaceGeneratorTest.kt
+++ b/aspoet/src/test/kotlin/com/google/androidstudiopoet/generators/BazelWorkspaceGeneratorTest.kt
@@ -24,8 +24,6 @@ class BazelWorkspaceGeneratorTest {
   private fun getBazelWorkspaceBlueprint(): BazelWorkspaceBlueprint {
     val blueprint = mock<BazelWorkspaceBlueprint>()
     whenever(blueprint.workspacePath).thenReturn("WORKSPACE")
-    whenever(blueprint.bazelWorkspaceContent)
-        .thenReturn("android_sdk_repository(name = \"androidsdk\")")
     return blueprint
   }
 

--- a/aspoet/src/test/kotlin/com/google/androidstudiopoet/generators/bazel/BazelLangTest.kt
+++ b/aspoet/src/test/kotlin/com/google/androidstudiopoet/generators/bazel/BazelLangTest.kt
@@ -1,0 +1,67 @@
+package com.google.androidstudiopoet.generators.bazel
+
+import com.google.androidstudiopoet.testutils.assertEquals
+import org.junit.Test
+
+class BazelLangTest {
+
+    @Test
+    fun `assignment statement is converted to string correctly`() {
+        val stmt = AssignmentStatement("foo", "\"bar\"")
+        stmt.toString().assertEquals("foo = \"bar\"")
+    }
+
+    @Test
+    fun `load statement is converted to string correctly`() {
+        val stmt = LoadStatement("@foo//bar:baz.bzl", listOf("foo", "bar"))
+        stmt.toString().assertEquals("""load("@foo//bar:baz.bzl", "foo", "bar")""")
+    }
+
+    @Test
+    fun `comment is converted to string correctly`() {
+        val comment = Comment("Foo bar baz")
+        comment.toString().assertEquals("# Foo bar baz")
+    }
+
+    @Test
+    fun `raw attribute is converted to string correctly`() {
+        val attr = RawAttribute("foo", "[1, 2, 3]")
+        attr.toString().assertEquals("foo = [1, 2, 3]")
+    }
+
+    @Test
+    fun `string attribute is converted to string correctly`() {
+        val attr = StringAttribute("foo", "bar")
+        attr.toString().assertEquals("foo = \"bar\"")
+    }
+
+    @Test
+    fun `target without attributes is converted to string correctly`() {
+        val target = Target("foo_bar", listOf())
+        target.toString().assertEquals("foo_bar()")
+    }
+
+    @Test
+    fun `target with one attribute is converted to string correctly`() {
+        val target = Target("foo_bar", listOf(RawAttribute("baz", "42")))
+        target.toString().assertEquals("""foo_bar(
+    baz = 42
+)""")
+    }
+
+    @Test
+    fun `target with two attributes is converted to string correctly`() {
+        val target = Target(
+            "foo_bar",
+            listOf(
+                RawAttribute("baz", "42"),
+                StringAttribute("qux", "foo")
+            ))
+        target.toString().assertEquals("""foo_bar(
+    baz = 42,
+    qux = "foo"
+)""")
+    }
+
+}
+

--- a/aspoet/src/test/kotlin/com/google/androidstudiopoet/generators/bazel/BazelLangTest.kt
+++ b/aspoet/src/test/kotlin/com/google/androidstudiopoet/generators/bazel/BazelLangTest.kt
@@ -64,4 +64,3 @@ class BazelLangTest {
     }
 
 }
-

--- a/aspoet/src/test/kotlin/com/google/androidstudiopoet/generators/bazel/BazelLangTest.kt
+++ b/aspoet/src/test/kotlin/com/google/androidstudiopoet/generators/bazel/BazelLangTest.kt
@@ -45,7 +45,7 @@ class BazelLangTest {
     fun `target with one attribute is converted to string correctly`() {
         val target = Target("foo_bar", listOf(RawAttribute("baz", "42")))
         target.toString().assertEquals("""foo_bar(
-    baz = 42
+    baz = 42,
 )""")
     }
 
@@ -59,7 +59,7 @@ class BazelLangTest {
             ))
         target.toString().assertEquals("""foo_bar(
     baz = 42,
-    qux = "foo"
+    qux = "foo",
 )""")
     }
 

--- a/aspoet/src/test/kotlin/com/google/androidstudiopoet/models/BazelWorkspaceBlueprintTest.kt
+++ b/aspoet/src/test/kotlin/com/google/androidstudiopoet/models/BazelWorkspaceBlueprintTest.kt
@@ -15,7 +15,9 @@ class BazelWorkspaceBlueprintTest {
   @Test
   fun `workspace file content contains android_sdk_repository declaration`() {
     val blueprint = getBazelWorkspaceBlueprint()
-    val androidSdkRepositoryDeclaration = "android_sdk_repository(name = \"androidsdk\")"
+    val androidSdkRepositoryDeclaration = """android_sdk_repository(
+    name = "androidsdk"
+)"""
     assert(blueprint.bazelWorkspaceContent.contains(androidSdkRepositoryDeclaration))
   }
 

--- a/aspoet/src/test/kotlin/com/google/androidstudiopoet/models/BazelWorkspaceBlueprintTest.kt
+++ b/aspoet/src/test/kotlin/com/google/androidstudiopoet/models/BazelWorkspaceBlueprintTest.kt
@@ -13,17 +13,12 @@ class BazelWorkspaceBlueprintTest {
   }
 
   @Test
-  fun `workspace file content contains android_sdk_repository declaration`() {
+  fun `blueprint stores GMAVEN_TAG in YYYYMMDD-{snapshot num} form`() {
     val blueprint = getBazelWorkspaceBlueprint()
-    val androidSdkRepositoryDeclaration = """android_sdk_repository(
-    name = "androidsdk",
-)"""
-    assert(blueprint.bazelWorkspaceContent.contains(androidSdkRepositoryDeclaration))
+    assert(blueprint.gmavenRulesTag.contains(Regex("\\d{8}-\\d+")))
   }
 
-  private fun getBazelWorkspaceBlueprint(
-      projectRoot: String = "foo"
-  ) = BazelWorkspaceBlueprint(projectRoot)
+  private fun getBazelWorkspaceBlueprint(projectRoot: String = "foo") = BazelWorkspaceBlueprint(projectRoot)
 
 }
 

--- a/aspoet/src/test/kotlin/com/google/androidstudiopoet/models/BazelWorkspaceBlueprintTest.kt
+++ b/aspoet/src/test/kotlin/com/google/androidstudiopoet/models/BazelWorkspaceBlueprintTest.kt
@@ -16,7 +16,7 @@ class BazelWorkspaceBlueprintTest {
   fun `workspace file content contains android_sdk_repository declaration`() {
     val blueprint = getBazelWorkspaceBlueprint()
     val androidSdkRepositoryDeclaration = """android_sdk_repository(
-    name = "androidsdk"
+    name = "androidsdk",
 )"""
     assert(blueprint.bazelWorkspaceContent.contains(androidSdkRepositoryDeclaration))
   }


### PR DESCRIPTION
Resolves @NikitaKozlov's comment at https://github.com/android/android-studio-poet/pull/133#discussion_r215959875

I've only migrated BazelWorkspaceBlueprint to use BazelLang to keep this PR small, will make the changes to BUILD.bazel generators in a follow up PR.
