### PR TITLE
Bump versions of libraries and Bazel dependencies

### DIFF
--- a/aspoet-input/src/main/kotlin/com/google/androidstudiopoet/input/AndroidBuildConfig.kt
+++ b/aspoet-input/src/main/kotlin/com/google/androidstudiopoet/input/AndroidBuildConfig.kt
@@ -16,4 +16,4 @@ limitations under the License.
 
 package com.google.androidstudiopoet.input
 
-data class AndroidBuildConfig(val minSdkVersion: Int = 19, val targetSdkVersion: Int = 27, val compileSdkVersion: Int = 27)
+data class AndroidBuildConfig(val minSdkVersion: Int = 19, val targetSdkVersion: Int = 28, val compileSdkVersion: Int = 28)

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/BazelWorkspaceGenerator.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/BazelWorkspaceGenerator.kt
@@ -39,6 +39,7 @@ class BazelWorkspaceGenerator(private val fileWriter: FileWriter) {
                     listOf(StringAttribute("name", "androidsdk")))}
 
 ${Comment("Google Maven Repository")}
+${LoadStatement("@bazel_tools//tools/build_defs/repo:http.bzl", listOf("http_archive"))}
 ${AssignmentStatement("GMAVEN_TAG", "\"${blueprint.gmavenRulesTag}\"")}
 ${Target(
     "http_archive",

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/AndroidBuildBazelBlueprint.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/AndroidBuildBazelBlueprint.kt
@@ -31,10 +31,10 @@ class AndroidBuildBazelBlueprint(val isApplication: Boolean,
 
     private fun createSetOfLibraries(): Set<GmavenBazelDependency> {
         return mutableSetOf(
-                GmavenBazelDependency("com.android.support:appcompat-v7:aar:26.1.0"),
-                GmavenBazelDependency("com.android.support.constraint:constraint-layout:aar:1.0.2"),
-                GmavenBazelDependency("com.android.support:multidex:aar:1.0.1"),
-                GmavenBazelDependency("com.android.support.test:runner:aar:1.0.1"),
-                GmavenBazelDependency("com.android.support.test.espresso:espresso-core:aar:3.0.1"))
+                GmavenBazelDependency("com.android.support:appcompat-v7:aar:28.0.0"),
+                GmavenBazelDependency("com.android.support.constraint:constraint-layout:aar:1.1.3"),
+                GmavenBazelDependency("com.android.support:multidex:aar:1.0.3"),
+                GmavenBazelDependency("com.android.support.test:runner:aar:1.0.2"),
+                GmavenBazelDependency("com.android.support.test.espresso:espresso-core:aar:3.0.2"))
     }
 }

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/AndroidBuildGradleBlueprint.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/AndroidBuildGradleBlueprint.kt
@@ -49,12 +49,12 @@ class AndroidBuildGradleBlueprint(val isApplication: Boolean, private val enable
 
     private fun createSetOfLibraries(): Set<LibraryDependency> {
         val result = mutableSetOf(
-                LibraryDependency("implementation", "com.android.support:appcompat-v7:26.1.0"),
-                LibraryDependency("implementation", "com.android.support.constraint:constraint-layout:1.0.2"),
+                LibraryDependency("implementation", "com.android.support:appcompat-v7:28.0.0"),
+                LibraryDependency("implementation", "com.android.support.constraint:constraint-layout:1.1.3"),
                 LibraryDependency("testImplementation", "junit:junit:4.12"),
-                LibraryDependency("androidTestImplementation", "com.android.support.test:runner:1.0.1"),
-                LibraryDependency("androidTestImplementation", "com.android.support.test.espresso:espresso-core:3.0.1"),
-                LibraryDependency("implementation", "com.android.support:multidex:1.0.1")
+                LibraryDependency("androidTestImplementation", "com.android.support.test:runner:1.0.2"),
+                LibraryDependency("androidTestImplementation", "com.android.support.test.espresso:espresso-core:3.0.2"),
+                LibraryDependency("implementation", "com.android.support:multidex:1.0.3")
         )
 
         if (enableKotlin) {

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/BazelWorkspaceBlueprint.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/BazelWorkspaceBlueprint.kt
@@ -20,6 +20,6 @@ class BazelWorkspaceBlueprint(val projectRoot: String) {
 
   val workspacePath = projectRoot.joinPath("WORKSPACE")
 
-  val gmavenRulesTag = "20180607-1"
+  val gmavenRulesTag = "20181212-2"
 
 }

--- a/aspoet/src/test/kotlin/com/google/androidstudiopoet/generators/BazelWorkspaceGeneratorTest.kt
+++ b/aspoet/src/test/kotlin/com/google/androidstudiopoet/generators/BazelWorkspaceGeneratorTest.kt
@@ -22,6 +22,7 @@ class BazelWorkspaceGeneratorTest {
 )
 
 # Google Maven Repository
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 GMAVEN_TAG = "19700101-1"
 http_archive(
     name = "gmaven_rules",
@@ -43,6 +44,7 @@ gmaven_rules()
 )
 
 # Google Maven Repository
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 GMAVEN_TAG = "20001212-42"
 http_archive(
     name = "gmaven_rules",

--- a/aspoet/src/test/kotlin/com/google/androidstudiopoet/models/AndroidBuildBazelBlueprintTest.kt
+++ b/aspoet/src/test/kotlin/com/google/androidstudiopoet/models/AndroidBuildBazelBlueprintTest.kt
@@ -29,11 +29,11 @@ class AndroidBuildBazelBlueprintTest {
 
         assertOn(blueprint) {
             libraries.assertEquals(setOf(
-                GmavenBazelDependency("com.android.support:appcompat-v7:aar:26.1.0"),
-                GmavenBazelDependency("com.android.support.constraint:constraint-layout:aar:1.0.2"),
-                GmavenBazelDependency("com.android.support:multidex:aar:1.0.1"),
-                GmavenBazelDependency("com.android.support.test:runner:aar:1.0.1"),
-                GmavenBazelDependency("com.android.support.test.espresso:espresso-core:aar:3.0.1")))
+                GmavenBazelDependency("com.android.support:appcompat-v7:aar:28.0.0"),
+                GmavenBazelDependency("com.android.support.constraint:constraint-layout:aar:1.1.3"),
+                GmavenBazelDependency("com.android.support:multidex:aar:1.0.3"),
+                GmavenBazelDependency("com.android.support.test:runner:aar:1.0.2"),
+                GmavenBazelDependency("com.android.support.test.espresso:espresso-core:aar:3.0.2")))
         }
     }
 

--- a/aspoet/src/test/kotlin/com/google/androidstudiopoet/models/AndroidBuildGradleBlueprintTest.kt
+++ b/aspoet/src/test/kotlin/com/google/androidstudiopoet/models/AndroidBuildGradleBlueprintTest.kt
@@ -101,12 +101,12 @@ class AndroidBuildGradleBlueprintTest {
 
         assertOn(blueprint) {
             libraries.assertEquals(setOf(
-                    LibraryDependency("implementation", "com.android.support:appcompat-v7:26.1.0"),
-                    LibraryDependency("implementation", "com.android.support.constraint:constraint-layout:1.0.2"),
+                    LibraryDependency("implementation", "com.android.support:appcompat-v7:28.0.0"),
+                    LibraryDependency("implementation", "com.android.support.constraint:constraint-layout:1.1.3"),
                     LibraryDependency("testImplementation", "junit:junit:4.12"),
-                    LibraryDependency("androidTestImplementation", "com.android.support.test:runner:1.0.1"),
-                    LibraryDependency("androidTestImplementation", "com.android.support.test.espresso:espresso-core:3.0.1"),
-                    LibraryDependency("implementation", "com.android.support:multidex:1.0.1")
+                    LibraryDependency("androidTestImplementation", "com.android.support.test:runner:1.0.2"),
+                    LibraryDependency("androidTestImplementation", "com.android.support.test.espresso:espresso-core:3.0.2"),
+                    LibraryDependency("implementation", "com.android.support:multidex:1.0.3")
             ))
         }
     }


### PR DESCRIPTION
This PR bumps the version of the libraries to their latest stable versions to fix breaking changes in the latest Bazel versions. I did not migrate the support libraries to their androidx.* counterparts to keep the scope small.