### PR TITLE
Remove deprecated `compile`

### DIFF
--- a/aspoet-input/build.gradle
+++ b/aspoet-input/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'kotlin'
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlin_version}"
-    testCompile "junit:junit:4.12"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlin_version}"
+    testImplementation "junit:junit:4.12"
 }

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/ModuleBuildGradleGenerator.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/ModuleBuildGradleGenerator.kt
@@ -42,8 +42,7 @@ class ModuleBuildGradleGenerator(private val fileWriter: FileWriter) {
     private fun dependenciesClosure(blueprint: ModuleBuildGradleBlueprint): Closure {
         val dependencyExpressions: Set<Statement> = blueprint.dependencies.mapNotNull { it.toExpression() }.toSet()
 
-        val statements = listOf(Expression("compile", "fileTree(dir: 'libs', include: ['*.jar'])")) +
-                dependencyExpressions
+        val statements = dependencyExpressions.toList()
         return Closure("dependencies", statements)
     }
 

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/android_modules/AndroidModuleBuildGradleGenerator.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/android_modules/AndroidModuleBuildGradleGenerator.kt
@@ -119,8 +119,7 @@ class AndroidModuleBuildGradleGenerator(val fileWriter: FileWriter) {
     private fun dependenciesClosure(blueprint: AndroidBuildGradleBlueprint): Closure {
         val dependencyExpressions: Set<Statement> = blueprint.dependencies.mapNotNull { it.toExpression() }.toSet()
 
-        val statements = listOf(Expression("implementation", "fileTree(dir: 'libs', include: ['*.jar'])")) +
-                dependencyExpressions
+        val statements = dependencyExpressions.toList()
         return Closure("dependencies", statements)
     }
 

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/ModuleBuildGradleBlueprint.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/ModuleBuildGradleBlueprint.kt
@@ -38,11 +38,11 @@ class ModuleBuildGradleBlueprint(
         val result = mutableSetOf<LibraryDependency>()
 
         if (enableKotlin) {
-            result += LibraryDependency("compile", "org.jetbrains.kotlin:kotlin-stdlib-jre8:${'$'}kotlin_version")
+            result += LibraryDependency("implementation", "org.jetbrains.kotlin:kotlin-stdlib-jre8:${'$'}kotlin_version")
         }
 
         if (generateTests) {
-            result += LibraryDependency("testCompile", "junit:junit:4.12")
+            result += LibraryDependency("testImplementation", "junit:junit:4.12")
         }
 
         return result

--- a/aspoet/src/test/kotlin/com/google/androidstudiopoet/generators/ModuleBuildGradleGeneratorTest.kt
+++ b/aspoet/src/test/kotlin/com/google/androidstudiopoet/generators/ModuleBuildGradleGeneratorTest.kt
@@ -37,7 +37,7 @@ class ModuleBuildGradleGeneratorTest {
         val expected = """apply plugin: 'plugin1'
 apply plugin: 'plugin2'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+
 }
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8""""
@@ -47,14 +47,13 @@ targetCompatibility = "1.8""""
     @Test
     fun `generator applies libraries from the blueprint`() {
         val blueprint = getModuleBuildGradleBlueprint(dependencies = setOf(
-                LibraryDependency("compile", "library1"),
-                LibraryDependency("testCompile", "library2")
+                LibraryDependency("implementation", "library1"),
+                LibraryDependency("testImplementation", "library2")
         ))
         buildGradleGenerator.generate(blueprint)
         val expected = """dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile "library1"
-    testCompile "library2"
+    implementation "library1"
+    testImplementation "library2"
 }
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8""""
@@ -64,14 +63,13 @@ targetCompatibility = "1.8""""
     @Test
     fun `generator applies dependencies from the blueprint`() {
         val blueprint = getModuleBuildGradleBlueprint(dependencies = setOf(
-                ModuleDependency("library1", mock(),"compile"),
-                ModuleDependency("library2", mock(),"testCompile")
+                ModuleDependency("library1", mock(),"implementation"),
+                ModuleDependency("library2", mock(),"testImplementation")
         ))
         buildGradleGenerator.generate(blueprint)
         val expected = """dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile project(':library1')
-    testCompile project(':library2')
+    implementation project(':library1')
+    testImplementation project(':library2')
 }
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8""""
@@ -86,7 +84,7 @@ targetCompatibility = "1.8""""
         ))
         buildGradleGenerator.generate(blueprint)
         val expected = """dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+
 }
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"

--- a/aspoet/src/test/kotlin/com/google/androidstudiopoet/generators/android_modules/AndroidModuleBuildGradleGeneratorTest.kt
+++ b/aspoet/src/test/kotlin/com/google/androidstudiopoet/generators/android_modules/AndroidModuleBuildGradleGeneratorTest.kt
@@ -38,7 +38,7 @@ android {
     }
 }
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
+
 }"""
         verify(fileWriter).writeToFile(expected, "path")
     }
@@ -69,7 +69,7 @@ dependencies {
     }
 }
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
+
 }"""
         verify(fileWriter).writeToFile(expected, "path")
     }
@@ -100,7 +100,7 @@ dependencies {
     }
 }
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
+
 }"""
         verify(fileWriter).writeToFile(expected, "path")
     }
@@ -131,7 +131,7 @@ dependencies {
     }
 }
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
+
 }"""
         verify(fileWriter).writeToFile(expected, "path")
     }
@@ -166,7 +166,6 @@ dependencies {
     }
 }
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "library1"
     testApi "library2"
     kapt "library3"
@@ -211,7 +210,7 @@ dependencies {
     }
 }
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
+
 }"""
         verify(fileWriter).writeToFile(expected, "path")
     }
@@ -252,7 +251,7 @@ dependencies {
     }
 }
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
+
 }"""
         verify(fileWriter).writeToFile(expected, "path")
     }
@@ -285,7 +284,7 @@ dependencies {
     }
 }
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
+
 }
 task1 {
     line1

--- a/aspoet/src/test/kotlin/com/google/androidstudiopoet/models/ModuleBuildGradleBlueprintTest.kt
+++ b/aspoet/src/test/kotlin/com/google/androidstudiopoet/models/ModuleBuildGradleBlueprintTest.kt
@@ -77,7 +77,7 @@ class ModuleBuildGradleBlueprintTest {
         val blueprint = createModuleBuildGradleBlueprint(enableKotlin = true)
 
         assertOn(blueprint) {
-            dependencies.assertContains(LibraryDependency("compile", "org.jetbrains.kotlin:kotlin-stdlib-jre8:${'$'}kotlin_version"))
+            dependencies.assertContains(LibraryDependency("implementation", "org.jetbrains.kotlin:kotlin-stdlib-jre8:${'$'}kotlin_version"))
         }
     }
 
@@ -86,7 +86,7 @@ class ModuleBuildGradleBlueprintTest {
         val blueprint = createModuleBuildGradleBlueprint(generateTests = true)
 
         assertOn(blueprint) {
-            dependencies.assertContains(LibraryDependency("testCompile", "junit:junit:4.12"))
+            dependencies.assertContains(LibraryDependency("testImplementation", "junit:junit:4.12"))
         }
     }
 


### PR DESCRIPTION
This field is deprecated and is removed in Gradle 7.0. This will allow performance tests to run against Gradle 7.0.

The `fileTree` dependency is also unecessary since the `libs` folder is not generated.
