### PR TITLE
Skip resource creation when not specified.

### DIFF
--- a/aspoet/build.gradle
+++ b/aspoet/build.gradle
@@ -1,18 +1,19 @@
 apply plugin: 'kotlin'
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlin_version}"
-    compile 'com.google.code.gson:gson:2.8.2'
-    compile 'com.squareup:javapoet:1.10.0'
-    compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2'
-    compile 'junit:junit:4.12'
-    compile 'commons-io:commons-io:2.6'
-    compile project(':aspoet-input')
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlin_version}"
+    implementation 'com.google.code.gson:gson:2.8.2'
+    implementation 'com.squareup:javapoet:1.10.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2'
+    implementation 'junit:junit:4.12'
+    implementation 'commons-io:commons-io:2.6'
+    implementation project(':aspoet-input')
 
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-inline:3.7.7'
-    testCompile 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
-    testCompile "org.jetbrains.kotlin:kotlin-reflect:${kotlin_version}"
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-inline:3.7.7'
+    testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
+    testImplementation "org.jetbrains.kotlin:kotlin-reflect:${kotlin_version}"
+    testImplementation "com.google.truth:truth:1.1.2"
 }
 
 // java -jar aspoet/build/libs/aspoet-all.jar
@@ -23,6 +24,6 @@ task fatJar(type: Jar) {
         )
     }
     baseName = project.name + '-all'
-    from { configurations.compile.collect { it.directory ? it : zipTree(it) } }
+    from { configurations.implementation.collect { it.directory ? it : zipTree(it) } }
     with jar
 }

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/AndroidModuleBlueprint.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/AndroidModuleBlueprint.kt
@@ -53,14 +53,20 @@ class AndroidModuleBlueprint(name: String,
                 .fold(ResourcesToRefer(listOf(), listOf(), listOf())) { acc, resourcesToRefer -> resourcesToRefer.combine(acc) }
     }
 
-    val resourcesBlueprint by lazy {
-        when (resourcesConfig) {
-            null -> null
-            else -> ResourcesBlueprint(name, resDirPath, resourcesConfig.stringCount ?: 0,
-                    resourcesConfig.imageCount ?: 0, resourcesConfig.layoutCount ?: 0, resourcesToReferWithin,
-                    listenerClassesForDataBinding)
-        }
+    val resourcesBlueprint : ResourcesBlueprint? by lazy {
+      when {
+        resourcesConfig == null -> null
+        resourcesConfig.isEmptyConfig() -> null
+        else -> ResourcesBlueprint(
+            name, resDirPath, resourcesConfig.stringCount ?: 0,
+            resourcesConfig.imageCount ?: 0, resourcesConfig.layoutCount ?: 0, resourcesToReferWithin,
+            listenerClassesForDataBinding
+          )
+      }
     }
+
+    private fun ResourcesConfig.isEmptyConfig() =
+     imageCount == 0 && layoutCount == 0 && stringCount == 0
 
     private val layoutBlueprints by lazy {
         resourcesBlueprint?.layoutBlueprints ?: listOf()

--- a/aspoet/src/test/kotlin/com/google/androidstudiopoet/models/AndroidModuleBlueprintTest.kt
+++ b/aspoet/src/test/kotlin/com/google/androidstudiopoet/models/AndroidModuleBlueprintTest.kt
@@ -2,6 +2,7 @@ package com.google.androidstudiopoet.models
 
 import com.google.androidstudiopoet.input.*
 import com.google.androidstudiopoet.testutils.*
+import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.whenever
 import org.junit.Test
 
@@ -21,15 +22,13 @@ class AndroidModuleBlueprintTest {
 
         val androidModuleBlueprint = getAndroidModuleBlueprint()
 
-        assertOn(androidModuleBlueprint) {
-            activityBlueprints.assertEquals(listOf(ActivityBlueprint(
+        assertThat(androidModuleBlueprint.activityBlueprints).isEqualTo(listOf(ActivityBlueprint(
                     "Activity0",
                     androidModuleBlueprint.resourcesBlueprint!!.layoutBlueprints[0],
                     androidModuleBlueprint.packagePath,
                     androidModuleBlueprint.packageName,
                     androidModuleBlueprint.packagesBlueprint.javaPackageBlueprints[0].classBlueprints[0],
                     listOf(), false)))
-        }
     }
 
     @Test
@@ -76,6 +75,13 @@ class AndroidModuleBlueprintTest {
         val androidModuleBlueprint = getAndroidModuleBlueprint(dataBindingConfig = DataBindingConfig(listenerCount = -1))
 
         androidModuleBlueprint.hasDataBinding.assertFalse()
+    }
+
+    @Test
+    fun `empty resource config generates null resources blueprint`() {
+      val androidModuleBlueprint = getAndroidModuleBlueprint(resourcesConfig = ResourcesConfig(0, 0, 0))
+
+      androidModuleBlueprint.resourcesBlueprint.assertNull()
     }
 
     private fun getAndroidModuleBlueprint(


### PR DESCRIPTION
Previously, an empty string.xml file would be generated even though no resources were specified.
This skips the generation of that file so that generated projects do not have to configure resources.
