### PR TITLE
Fix fatjar task

### DIFF
--- a/aspoet/build.gradle
+++ b/aspoet/build.gradle
@@ -24,6 +24,6 @@ task fatJar(type: Jar) {
         )
     }
     baseName = project.name + '-all'
-    from { configurations.implementation.collect { it.directory ? it : zipTree(it) } }
+    from { configurations.runtimeClasspath.collect { it.directory ? it : zipTree(it) } }
     with jar
 }


### PR DESCRIPTION
This avoids the following Gradle error:

    "Resolving dependency configuration 'implementation' is
    not allowed as it is defined as 'canBeResolved=false'."