### PR TITLE
Fix Kotlin stdlib dependency

### DIFF
--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/AndroidBuildGradleBlueprint.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/AndroidBuildGradleBlueprint.kt
@@ -58,7 +58,7 @@ class AndroidBuildGradleBlueprint(val isApplication: Boolean, private val enable
         )
 
         if (enableKotlin) {
-            result += LibraryDependency("implementation", "org.jetbrains.kotlin:kotlin-stdlib-jre8:${'$'}kotlin_version")
+            result += LibraryDependency("implementation", "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${'$'}kotlin_version")
         }
 
         if (enableKotlin && enableDataBinding) {

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/ModuleBuildGradleBlueprint.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/ModuleBuildGradleBlueprint.kt
@@ -38,7 +38,7 @@ class ModuleBuildGradleBlueprint(
         val result = mutableSetOf<LibraryDependency>()
 
         if (enableKotlin) {
-            result += LibraryDependency("implementation", "org.jetbrains.kotlin:kotlin-stdlib-jre8:${'$'}kotlin_version")
+            result += LibraryDependency("implementation", "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${'$'}kotlin_version")
         }
 
         if (generateTests) {

--- a/aspoet/src/test/kotlin/com/google/androidstudiopoet/models/AndroidBuildGradleBlueprintTest.kt
+++ b/aspoet/src/test/kotlin/com/google/androidstudiopoet/models/AndroidBuildGradleBlueprintTest.kt
@@ -115,7 +115,7 @@ class AndroidBuildGradleBlueprintTest {
         val blueprint = createAndroidBuildGradleBlueprint(enableKotlin = true)
 
         assertOn(blueprint) {
-            libraries.assertContains(LibraryDependency("implementation", "org.jetbrains.kotlin:kotlin-stdlib-jre8:${'$'}kotlin_version"))
+            libraries.assertContains(LibraryDependency("implementation", "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${'$'}kotlin_version"))
         }
     }
 

--- a/aspoet/src/test/kotlin/com/google/androidstudiopoet/models/ModuleBuildGradleBlueprintTest.kt
+++ b/aspoet/src/test/kotlin/com/google/androidstudiopoet/models/ModuleBuildGradleBlueprintTest.kt
@@ -77,7 +77,7 @@ class ModuleBuildGradleBlueprintTest {
         val blueprint = createModuleBuildGradleBlueprint(enableKotlin = true)
 
         assertOn(blueprint) {
-            dependencies.assertContains(LibraryDependency("implementation", "org.jetbrains.kotlin:kotlin-stdlib-jre8:${'$'}kotlin_version"))
+            dependencies.assertContains(LibraryDependency("implementation", "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${'$'}kotlin_version"))
         }
     }
 


### PR DESCRIPTION
kotlin-stdlib-jre8 is deprecated and replaced by kotlin-stdlib-jdk8.