### PR TITLE
Create Kotlin generators for Android Activity

### DIFF
--- a/aspoet/build.gradle
+++ b/aspoet/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlin_version}"
     implementation 'com.google.code.gson:gson:2.8.2'
     implementation 'com.squareup:javapoet:1.10.0'
+    implementation 'com.squareup:kotlinpoet:1.10.1'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2'
     implementation 'junit:junit:4.12'
     implementation 'commons-io:commons-io:2.6'

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/Injector.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/Injector.kt
@@ -57,7 +57,8 @@ object Injector {
             layoutResourcesGenerator, fileWriter)
     private val javaGenerator: JavaGenerator = JavaGenerator(fileWriter)
     private val kotlinGenerator: KotlinGenerator = KotlinGenerator(fileWriter)
-    private val activityGenerator: ActivityGenerator = ActivityGenerator(fileWriter)
+    private val javaActivityGenerator: JavaActivityGenerator = JavaActivityGenerator(fileWriter)
+    private val kotlinActivityGenerator: KotlinActivityGenerator = KotlinActivityGenerator(fileWriter)
     private val manifestGenerator: ManifestGenerator = ManifestGenerator(fileWriter)
     private val proguardGenerator: ProguardGenerator = ProguardGenerator(fileWriter)
     private val packagesGenerator = PackagesGenerator(javaGenerator, kotlinGenerator)
@@ -78,8 +79,10 @@ object Injector {
             AndroidModuleGenerator(
                     resourcesGenerator,
                     packagesGenerator,
-                    activityGenerator,
-                    manifestGenerator, proguardGenerator,
+                    javaActivityGenerator,
+                    kotlinActivityGenerator,
+                    manifestGenerator,
+                    proguardGenerator,
                     amBuildGradleGenerator,
                     amBazelBuildGenerator,
                     fileWriter)

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/android_modules/ActivityGenerator.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/android_modules/ActivityGenerator.kt
@@ -16,76 +16,8 @@ limitations under the License.
 
 package com.google.androidstudiopoet.generators.android_modules
 
-import com.google.androidstudiopoet.generators.packages.toJavaSpec
 import com.google.androidstudiopoet.models.ActivityBlueprint
-import com.google.androidstudiopoet.models.ClassBlueprint
-import com.google.androidstudiopoet.models.FieldBlueprint
-import com.google.androidstudiopoet.writers.FileWriter
-import com.squareup.javapoet.*
-import javax.lang.model.element.Modifier
 
-
-class ActivityGenerator(var fileWriter: FileWriter) {
-
-    fun generate(blueprint: ActivityBlueprint) {
-
-        val onCreateMethodStatements = getOnCreateMethodStatements(blueprint)
-
-        val onCreateMethod = getOnCreateMethod(onCreateMethodStatements)
-
-        val activityClassBuilder = getClazzSpec(blueprint.className)
-                .addMethod(onCreateMethod)
-
-        blueprint.fields.map {
-            it.toJavaSpec()
-        }.forEach {
-            activityClassBuilder.addField(it)
-        }
-
-        val activityClass = activityClassBuilder
-                .build()
-
-        val javaFile = JavaFile.builder(blueprint.packageName, activityClass).build()
-        fileWriter.writeToFile(javaFile.toString(), "${blueprint.where}/${blueprint.className}.java")
-    }
-
-    private fun getOnCreateMethodStatements(blueprint: ActivityBlueprint): List<String> {
-        val classBlueprint = blueprint.classToReferFromActivity
-        val statements = getMethodStatementFromClassToCall(classBlueprint)?.let { mutableListOf(it) } ?: mutableListOf()
-
-        if (blueprint.hasDataBinding) {
-            statements.addAll(getDataBindingMethodStatements(blueprint.layout.name, blueprint.dataBindingClassName, blueprint.listenerClassesForDataBinding))
-        } else {
-            statements.add("setContentView(R.layout.${blueprint.layout.name})")
-        }
-        return statements
-    }
-
-    private fun getDataBindingMethodStatements(layout: String, dataBindingClassName: String,
-                                               listenerClasses: List<ClassBlueprint>): List<String> {
-        return listOf("$dataBindingClassName binding = androidx.databinding.DataBindingUtil.setContentView(this, R.layout.$layout)") +
-        listenerClasses.map { "binding.set${it.className}(new ${it.fullClassName}())" }
-    }
-
-    private fun getMethodStatementFromClassToCall(classBlueprint: ClassBlueprint) =
-            classBlueprint.getMethodToCallFromOutside()?.let { "new ${it.className}().${it.methodName}()" }
-
-    private fun getClazzSpec(activityClassName: String) =
-            TypeSpec.classBuilder(activityClassName)
-                    .superclass(TypeVariableName.get("android.app.Activity"))
-                    .addModifiers(Modifier.PUBLIC)
-
-    private fun getOnCreateMethod(statements: List<String>): MethodSpec {
-
-        val builder = MethodSpec.methodBuilder("onCreate")
-                .addAnnotation(Override::class.java)
-                .addModifiers(Modifier.PUBLIC)
-                .returns(Void.TYPE)
-                .addParameter(TypeVariableName.get("android.os.Bundle"), "savedInstanceState")
-                .addStatement("super.onCreate(savedInstanceState)")
-
-        statements.forEach { builder.addStatement(it) }
-        return builder.build()
-    }
-
+interface ActivityGenerator {
+    fun generate(blueprint: ActivityBlueprint)
 }

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/android_modules/AndroidModuleGenerator.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/android_modules/AndroidModuleGenerator.kt
@@ -25,7 +25,8 @@ import java.util.*
 
 class AndroidModuleGenerator(private val resourcesGenerator: ResourcesGenerator,
                              private val packagesGenerator: PackagesGenerator,
-                             private val activityGenerator: ActivityGenerator,
+                             private val javaActivityGenerator: JavaActivityGenerator,
+                             private val kotlinActivityGenerator: KotlinActivityGenerator,
                              private val manifestGenerator: ManifestGenerator,
                              private val proguardGenerator: ProguardGenerator,
                              private val buildGradleGenerator: AndroidModuleBuildGradleGenerator,
@@ -42,7 +43,13 @@ class AndroidModuleGenerator(private val resourcesGenerator: ResourcesGenerator,
         buildGradleGenerator.generate(blueprint.buildGradleBlueprint)
         blueprint.resourcesBlueprint?.let { resourcesGenerator.generate(it, random) }
         packagesGenerator.writePackages(blueprint.packagesBlueprint)
-        blueprint.activityBlueprints.forEach({ activityGenerator.generate(it) })
+        blueprint.activityBlueprints.forEach { activityBlueprint ->
+            if (blueprint.useKotlin) {
+                kotlinActivityGenerator.generate(activityBlueprint)
+            } else {
+                javaActivityGenerator.generate(activityBlueprint)
+            }
+        }
         manifestGenerator.generate(blueprint)
 
         blueprint.buildBazelBlueprint?.let {

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/android_modules/JavaActivityGenerator.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/android_modules/JavaActivityGenerator.kt
@@ -1,0 +1,91 @@
+/*
+Copyright 2021 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package com.google.androidstudiopoet.generators.android_modules
+
+import com.google.androidstudiopoet.generators.packages.toJavaSpec
+import com.google.androidstudiopoet.models.ActivityBlueprint
+import com.google.androidstudiopoet.models.ClassBlueprint
+import com.google.androidstudiopoet.writers.FileWriter
+import com.squareup.javapoet.JavaFile
+import com.squareup.javapoet.MethodSpec
+import com.squareup.javapoet.TypeSpec
+import com.squareup.javapoet.TypeVariableName
+import javax.lang.model.element.Modifier
+
+
+class JavaActivityGenerator(var fileWriter: FileWriter): ActivityGenerator {
+
+    override fun generate(blueprint: ActivityBlueprint) {
+
+        val onCreateMethodStatements = getOnCreateMethodStatements(blueprint)
+
+        val onCreateMethod = getOnCreateMethod(onCreateMethodStatements)
+
+        val activityClassBuilder = getClazzSpec(blueprint.className)
+                .addMethod(onCreateMethod)
+
+        blueprint.fields.map {
+            it.toJavaSpec()
+        }.forEach {
+            activityClassBuilder.addField(it)
+        }
+
+        val activityClass = activityClassBuilder
+                .build()
+
+        val javaFile = JavaFile.builder(blueprint.packageName, activityClass).build()
+        fileWriter.writeToFile(javaFile.toString(), "${blueprint.where}/${blueprint.className}.java")
+    }
+
+    private fun getOnCreateMethodStatements(blueprint: ActivityBlueprint): List<String> {
+        val classBlueprint = blueprint.classToReferFromActivity
+        val statements = getMethodStatementFromClassToCall(classBlueprint)?.let { mutableListOf(it) } ?: mutableListOf()
+
+        if (blueprint.hasDataBinding) {
+            statements.addAll(getDataBindingMethodStatements(blueprint.layout.name, blueprint.dataBindingClassName, blueprint.listenerClassesForDataBinding))
+        } else {
+            statements.add("setContentView(R.layout.${blueprint.layout.name})")
+        }
+        return statements
+    }
+
+    private fun getDataBindingMethodStatements(layout: String, dataBindingClassName: String,
+                                               listenerClasses: List<ClassBlueprint>): List<String> {
+        return listOf("$dataBindingClassName binding = androidx.databinding.DataBindingUtil.setContentView(this, R.layout.$layout)") +
+        listenerClasses.map { "binding.set${it.className}(new ${it.fullClassName}())" }
+    }
+
+    private fun getMethodStatementFromClassToCall(classBlueprint: ClassBlueprint) =
+            classBlueprint.getMethodToCallFromOutside()?.let { "new ${it.className}().${it.methodName}()" }
+
+    private fun getClazzSpec(activityClassName: String) =
+            TypeSpec.classBuilder(activityClassName)
+                    .superclass(TypeVariableName.get("android.app.Activity"))
+                    .addModifiers(Modifier.PUBLIC)
+
+    private fun getOnCreateMethod(statements: List<String>): MethodSpec {
+
+        val builder = MethodSpec.methodBuilder("onCreate")
+                .addAnnotation(Override::class.java)
+                .addModifiers(Modifier.PUBLIC)
+                .returns(Void.TYPE)
+                .addParameter(TypeVariableName.get("android.os.Bundle"), "savedInstanceState")
+                .addStatement("super.onCreate(savedInstanceState)")
+
+        statements.forEach { builder.addStatement(it) }
+        return builder.build()
+    }
+}

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/android_modules/KotlinActivityGenerator.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/android_modules/KotlinActivityGenerator.kt
@@ -1,0 +1,92 @@
+/*
+Copyright 2021 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.google.androidstudiopoet.generators.android_modules
+
+import com.google.androidstudiopoet.models.ActivityBlueprint
+import com.google.androidstudiopoet.models.AnnotationBlueprint
+import com.google.androidstudiopoet.models.FieldBlueprint
+import com.google.androidstudiopoet.writers.FileWriter
+import com.squareup.kotlinpoet.*
+import com.squareup.kotlinpoet.MemberName.Companion.member
+
+
+class KotlinActivityGenerator(var fileWriter: FileWriter): ActivityGenerator {
+
+    override fun generate(blueprint: ActivityBlueprint) {
+
+        val activityClassBuilder = getClazzSpec(blueprint.className)
+        blueprint.fields.forEach {
+            activityClassBuilder.addProperty(it.toPropertySpec())
+        }
+        activityClassBuilder.addFunction(blueprint.toOnCreateFunSpec())
+        val content = buildString {
+            FileSpec.builder(blueprint.packageName, blueprint.className)
+                    .addType(activityClassBuilder.build())
+                    .build()
+                    .writeTo(this)
+        }
+        fileWriter.writeToFile(content, "${blueprint.where}/${blueprint.className}.kt")
+    }
+
+    private fun getClazzSpec(activityClassName: String) =
+            TypeSpec.classBuilder(activityClassName)
+                    .superclass(ClassName("android.app", "Activity"))
+
+    private fun FieldBlueprint.toPropertySpec(): PropertySpec {
+        val propertySpec = PropertySpec.builder(name, ClassName.bestGuess(typeName))
+                .mutable()
+                .addModifiers(KModifier.LATEINIT)
+        annotations.forEach {
+            propertySpec.addAnnotation(it.toAnnotationSpec())
+        }
+        return propertySpec.build()
+    }
+
+    private fun AnnotationBlueprint.toAnnotationSpec(): AnnotationSpec {
+        val builder = AnnotationSpec.builder(ClassName.bestGuess(className))
+        params.forEach { (key, value) ->
+            builder.addMember("$key = %S", value)
+        }
+        return builder.build()
+    }
+
+    private fun ActivityBlueprint.toOnCreateFunSpec(): FunSpec {
+        val builder = FunSpec.builder("onCreate")
+                .addModifiers(KModifier.OVERRIDE)
+                .returns(Unit::class)
+                .addParameter(
+                        "savedInstanceState",
+                        ClassName("android.os", "Bundle").copy(nullable = true)
+                )
+                .addStatement("super.onCreate(savedInstanceState)")
+        classToReferFromActivity.getMethodToCallFromOutside()?.let {
+            val className = ClassName.bestGuess(it.className)
+            builder.addStatement("%T().%N()", className, className.member(it.methodName))
+        }
+        if (hasDataBinding) {
+            val bindingClassName = ClassName.bestGuess(dataBindingClassName)
+            val dataBindingUtil = ClassName("androidx.databinding", "DataBindingUtil")
+            builder.addStatement("val binding: %T = %T.setContentView(this, R.layout.${layout.name})", bindingClassName, dataBindingUtil)
+            listenerClassesForDataBinding.forEach {
+                builder.addStatement("binding.%N = %T()", it.className.decapitalize(), ClassName.bestGuess(it.fullClassName))
+            }
+        } else {
+            builder.addStatement("setContentView(R.layout.${layout.name})")
+        }
+        return builder.build()
+    }
+}

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/packages/JavaGenerator.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/packages/JavaGenerator.kt
@@ -20,7 +20,6 @@ import com.google.androidstudiopoet.models.AnnotationBlueprint
 import com.google.androidstudiopoet.models.ClassBlueprint
 import com.google.androidstudiopoet.models.FieldBlueprint
 import com.google.androidstudiopoet.models.MethodBlueprint
-import com.google.androidstudiopoet.models.MethodToCall
 import com.google.androidstudiopoet.writers.FileWriter
 import com.squareup.javapoet.AnnotationSpec
 import com.squareup.javapoet.ClassName
@@ -59,7 +58,7 @@ class JavaGenerator constructor(fileWriter: FileWriter) : PackageGenerator(fileW
                 .addModifiers(Modifier.PUBLIC)
                 .returns(Void.TYPE)
 
-        blueprint.annotationBlueprints.forEach { it -> method.addAnnotation(it.toJavaSpec()) }
+        blueprint.annotationBlueprints.forEach { method.addAnnotation(it.toJavaSpec()) }
 
         blueprint.statements.forEach { statement -> statement?.let { method.addStatement(it) } }
 


### PR DESCRIPTION
## Summary
Jetpack Compose only supports Kotlin, however, Activity can only be generated in Java as of today.

This PR adds the functionally to generate Activity in Kolin if `kotlinPackageCount`/`useKotlin` is true.

## Testing
Tested the generated project with `dataBindingConfig` enabled and disabled. In both cases, I was able to run the app without encountering compilation errors.