### PR TITLE
Add compose support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Create a real life complexity Android project that mimics your own and observe t
 * Configurable number of packages
 * Configurable number of classes
 * Configurable number of inter module dependencies
-* Android resources (images, strings,activities, layouts)
+* Android resources (images, strings, activities, layouts)
+* Configure how to generate UI layer code
 * Configurable version of gradle, kotlin, the android gradle plugin
 * Experimental Bazel support
 
@@ -43,6 +44,12 @@ will crawl the folder recursively and execute each config in turn.
 * You can have both source and resources inter-module dependencies
 
 This is not an official Google product.
+
+## UI layer code
+* Specify `dataBindingConfig` for data binding. It has a property `listenerCount` to indicate the number of data variables.
+* Specify `composeConfig` for compose. It has a property `actionCount` to indicate the number of clickable actions.
+* If nothing above is specified, the UI layer code will be traditional XML-based layout.
+* We cannot expect deterministic ordering when more than one configs are specified.
 
 ### License
 

--- a/aspoet-input/src/main/kotlin/com/google/androidstudiopoet/input/AndroidModuleConfig.kt
+++ b/aspoet-input/src/main/kotlin/com/google/androidstudiopoet/input/AndroidModuleConfig.kt
@@ -18,7 +18,7 @@ package com.google.androidstudiopoet.input
 
 class AndroidModuleConfig : ModuleConfig() {
 
-    var androidBuildConfig: AndroidBuildConfig? = null
+    var androidBuildConfig: AndroidBuildConfig = AndroidBuildConfig()
 
     var activityCount: Int = 0
     var productFlavorConfigs: List<FlavorConfig>? = null
@@ -27,4 +27,5 @@ class AndroidModuleConfig : ModuleConfig() {
 
     var resourcesConfig: ResourcesConfig? = null
     var dataBindingConfig: DataBindingConfig? = null
+    var composeConfig: ComposeConfig? = null
 }

--- a/aspoet-input/src/main/kotlin/com/google/androidstudiopoet/input/ComposeConfig.kt
+++ b/aspoet-input/src/main/kotlin/com/google/androidstudiopoet/input/ComposeConfig.kt
@@ -1,0 +1,3 @@
+package com.google.androidstudiopoet.input
+
+class ComposeConfig(val actionCount: Int = 0)

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToAndroidModuleConfigConverter.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToAndroidModuleConfigConverter.kt
@@ -53,6 +53,7 @@ class ConfigPojoToAndroidModuleConfigConverter {
             extraLines = config.extraAndroidBuildFileLines
             resourcesConfig = ResourcesConfig(activityCount + 2, activityCount + 5, activityCount)
             dataBindingConfig = config.dataBindingConfig
+            composeConfig = config.composeConfig
         }
     }
 }

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/android_modules/JavaActivityGenerator.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/android_modules/JavaActivityGenerator.kt
@@ -54,7 +54,7 @@ class JavaActivityGenerator(var fileWriter: FileWriter): ActivityGenerator {
         val classBlueprint = blueprint.classToReferFromActivity
         val statements = getMethodStatementFromClassToCall(classBlueprint)?.let { mutableListOf(it) } ?: mutableListOf()
 
-        if (blueprint.hasDataBinding) {
+        if (blueprint.enableDataBinding) {
             statements.addAll(getDataBindingMethodStatements(blueprint.layout.name, blueprint.dataBindingClassName, blueprint.listenerClassesForDataBinding))
         } else {
             statements.add("setContentView(R.layout.${blueprint.layout.name})")

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/input/ConfigPOJO.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/input/ConfigPOJO.kt
@@ -86,16 +86,18 @@ class ConfigPOJO {
 
     var libraries: List<DependencyConfig.LibraryDependencyConfig>? = null
 
-    var extraBuildFileLines : List<String>? = null
+    var extraBuildFileLines: List<String>? = null
 
-    var extraAndroidBuildFileLines : List<String>? = null
+    var extraAndroidBuildFileLines: List<String>? = null
 
-    var generateTests : Boolean = false
+    var generateTests: Boolean = false
 
-    var generateBazelFiles : Boolean = false
+    var generateBazelFiles: Boolean = false
 
     // Will use same data binding configuration for all android modules
     var dataBindingConfig: DataBindingConfig? = null
+
+    var composeConfig: ComposeConfig? = null
 
     override fun toString(): String = toJson()
 

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/ActivityBlueprint.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/ActivityBlueprint.kt
@@ -2,10 +2,15 @@ package com.google.androidstudiopoet.models
 
 import com.google.androidstudiopoet.utils.fold
 
-data class ActivityBlueprint(val className: String, val layout: LayoutBlueprint, val where: String, val packageName: String,
-                             val classToReferFromActivity: ClassBlueprint, val listenerClassesForDataBinding: List<ClassBlueprint>,
+data class ActivityBlueprint(val className: String,
+                             val enableCompose: Boolean,
+                             val layout: LayoutBlueprint,
+                             val where: String,
+                             val packageName: String,
+                             val classToReferFromActivity: ClassBlueprint,
+                             val listenerClassesForDataBinding: List<ClassBlueprint>,
                              private val useButterknife: Boolean) {
-    val hasDataBinding = listenerClassesForDataBinding.isNotEmpty()
+    val enableDataBinding = listenerClassesForDataBinding.isNotEmpty()
     val dataBindingClassName = "$packageName.databinding.${layout.name.toDataBindingShortClassName()}"
 
     val fields: Set<FieldBlueprint> =

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/AndroidBuildGradleBlueprint.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/AndroidBuildGradleBlueprint.kt
@@ -22,10 +22,17 @@ import com.google.androidstudiopoet.input.FlavorConfig
 import com.google.androidstudiopoet.input.PluginConfig
 import com.google.androidstudiopoet.utils.joinPath
 
-class AndroidBuildGradleBlueprint(val isApplication: Boolean, private val enableKotlin: Boolean, val enableDataBinding: Boolean,
-                                  moduleRoot: String, androidBuildConfig: AndroidBuildConfig, val packageName: String,
-                                  val extraLines: List<String>?, productFlavorConfigs: List<FlavorConfig>?,
-                                  buildTypeConfigs: List<BuildTypeConfig>?, additionalDependencies: Set<Dependency>,
+class AndroidBuildGradleBlueprint(val isApplication: Boolean,
+                                  private val enableKotlin: Boolean,
+                                  val enableCompose: Boolean,
+                                  val enableDataBinding: Boolean,
+                                  moduleRoot: String,
+                                  androidBuildConfig: AndroidBuildConfig,
+                                  val packageName: String,
+                                  val extraLines: List<String>?,
+                                  productFlavorConfigs: List<FlavorConfig>?,
+                                  buildTypeConfigs: List<BuildTypeConfig>?,
+                                  additionalDependencies: Set<Dependency>,
                                   pluginConfigs: List<PluginConfig>?) {
     val plugins: Set<String> = createSetOfPlugins(pluginConfigs)
 
@@ -59,6 +66,14 @@ class AndroidBuildGradleBlueprint(val isApplication: Boolean, private val enable
 
         if (enableKotlin) {
             result += LibraryDependency("implementation", "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${'$'}kotlin_version")
+        }
+
+        if (enableCompose) {
+            result += LibraryDependency("implementation", "androidx.compose.ui:ui:1.0.4")
+            result += LibraryDependency("implementation", "androidx.compose.material:material:1.0.4")
+            result += LibraryDependency("implementation", "androidx.activity:activity-compose:1.3.1")
+            result += LibraryDependency("androidTestImplementation", "androidx.compose.ui:ui-test-junit4:1.0.4")
+            result += LibraryDependency("debugImplementation", "androidx.compose.ui:ui-tooling:1.0.4")
         }
 
         return result

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/LayoutBlueprint.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/LayoutBlueprint.kt
@@ -18,27 +18,32 @@ package com.google.androidstudiopoet.models
 
 import com.google.androidstudiopoet.utils.joinPath
 
-class LayoutBlueprint(val name: String, layoutsDir: String,
-                      stringsWithDataBindingListenersToUse: List<Pair<String, ClassBlueprint?>>,
-                      imagesWithDataBindingListenersToUse: List<Pair<String, ClassBlueprint?>>,
+class LayoutBlueprint(val name: String,
+                      layoutsDir: String,
+                      private val enableCompose: Boolean,
+                      textsWithActions: List<Pair<String, ClassBlueprint?>>,
+                      imagesWithActions: List<Pair<String, ClassBlueprint?>>,
                       val layoutsToInclude: List<String>) {
 
     val filePath = layoutsDir.joinPath(name) + ".xml"
-    val textViewsBlueprints = stringsWithDataBindingListenersToUse.mapIndexed { index, it ->
+    val textViewsBlueprints = textsWithActions.mapIndexed { index, it ->
         TextViewBlueprint("$name${it.first}$index", it.first, it.second?.toOnClickAction())
     }
 
-    val imageViewsBlueprints = imagesWithDataBindingListenersToUse.mapIndexed { index, it ->
+    val imageViewsBlueprints = imagesWithActions.mapIndexed { index, it ->
         ImageViewBlueprint("$name${it.first}$index", it.first, it.second?.toOnClickAction())
     }
 
     val classesToBind
-            = (stringsWithDataBindingListenersToUse + imagesWithDataBindingListenersToUse).mapNotNull { it.second }
+            = (textsWithActions + imagesWithActions).mapNotNull { it.second }
 
     val hasLayoutTag = classesToBind.isNotEmpty()
-}
 
-
-fun ClassBlueprint.toOnClickAction(): String {
-    return "(view) -> ${className.decapitalize()}.${getMethodToCallFromOutside()!!.methodName}()"
+    private fun ClassBlueprint.toOnClickAction(): String {
+        return if (enableCompose) {
+            "${className}().${getMethodToCallFromOutside()!!.methodName}()"
+        } else {
+            "(view) -> ${className.decapitalize()}.${getMethodToCallFromOutside()!!.methodName}()"
+        }
+    }
 }

--- a/aspoet/src/test/kotlin/com/google/androidstudiopoet/generators/android_modules/AndroidModuleBuildGradleGeneratorTest.kt
+++ b/aspoet/src/test/kotlin/com/google/androidstudiopoet/generators/android_modules/AndroidModuleBuildGradleGeneratorTest.kt
@@ -14,32 +14,33 @@ class AndroidModuleBuildGradleGeneratorTest {
     fun `generator applies plugins from the blueprint`() {
         val blueprint = getAndroidBuildGradleBlueprint(plugins = setOf("plugin1", "plugin2"))
         androidModuleBuildGradleGenerator.generate(blueprint)
-        val expected = """apply plugin: 'plugin1'
-apply plugin: 'plugin2'
-android {
-    compileSdkVersion 0
-    defaultConfig {
-        minSdkVersion 0
-        targetSdkVersion 0
-        versionCode 1
-        versionName "1.0"
-        multiDexEnabled true
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-    }
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
-    }
-    compileOptions {
-        targetCompatibility 1.8
-        sourceCompatibility 1.8
-    }
-}
-dependencies {
-
-}"""
+        val expected = """
+            apply plugin: 'plugin1'
+            apply plugin: 'plugin2'
+            android {
+                compileSdkVersion 0
+                defaultConfig {
+                    minSdkVersion 0
+                    targetSdkVersion 0
+                    versionCode 1
+                    versionName "1.0"
+                    multiDexEnabled true
+                    testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+                }
+                buildTypes {
+                    release {
+                        minifyEnabled false
+                        proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+                    }
+                }
+                compileOptions {
+                    targetCompatibility 1.8
+                    sourceCompatibility 1.8
+                }
+            }
+            dependencies {
+            
+            }""".trimIndent()
         verify(fileWriter).writeToFile(expected, "path")
     }
 
@@ -47,30 +48,31 @@ dependencies {
     fun `generator applies compileSdkVersion from the blueprint`() {
         val blueprint = getAndroidBuildGradleBlueprint(compileSdkVersion = 27)
         androidModuleBuildGradleGenerator.generate(blueprint)
-        val expected = """android {
-    compileSdkVersion 27
-    defaultConfig {
-        minSdkVersion 0
-        targetSdkVersion 0
-        versionCode 1
-        versionName "1.0"
-        multiDexEnabled true
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-    }
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
-    }
-    compileOptions {
-        targetCompatibility 1.8
-        sourceCompatibility 1.8
-    }
-}
-dependencies {
-
-}"""
+        val expected = """
+            android {
+                compileSdkVersion 27
+                defaultConfig {
+                    minSdkVersion 0
+                    targetSdkVersion 0
+                    versionCode 1
+                    versionName "1.0"
+                    multiDexEnabled true
+                    testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+                }
+                buildTypes {
+                    release {
+                        minifyEnabled false
+                        proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+                    }
+                }
+                compileOptions {
+                    targetCompatibility 1.8
+                    sourceCompatibility 1.8
+                }
+            }
+            dependencies {
+            
+            }""".trimIndent()
         verify(fileWriter).writeToFile(expected, "path")
     }
 
@@ -78,30 +80,31 @@ dependencies {
     fun `generator applies minSdkVersion from the blueprint`() {
         val blueprint = getAndroidBuildGradleBlueprint(minSdkVersion = 27)
         androidModuleBuildGradleGenerator.generate(blueprint)
-        val expected = """android {
-    compileSdkVersion 0
-    defaultConfig {
-        minSdkVersion 27
-        targetSdkVersion 0
-        versionCode 1
-        versionName "1.0"
-        multiDexEnabled true
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-    }
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
-    }
-    compileOptions {
-        targetCompatibility 1.8
-        sourceCompatibility 1.8
-    }
-}
-dependencies {
-
-}"""
+        val expected = """
+            android {
+                compileSdkVersion 0
+                defaultConfig {
+                    minSdkVersion 27
+                    targetSdkVersion 0
+                    versionCode 1
+                    versionName "1.0"
+                    multiDexEnabled true
+                    testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+                }
+                buildTypes {
+                    release {
+                        minifyEnabled false
+                        proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+                    }
+                }
+                compileOptions {
+                    targetCompatibility 1.8
+                    sourceCompatibility 1.8
+                }
+            }
+            dependencies {
+            
+            }""".trimIndent()
         verify(fileWriter).writeToFile(expected, "path")
     }
 
@@ -109,30 +112,31 @@ dependencies {
     fun `generator applies targetSdkVersion from the blueprint`() {
         val blueprint = getAndroidBuildGradleBlueprint(targetSdkVersion = 27)
         androidModuleBuildGradleGenerator.generate(blueprint)
-        val expected = """android {
-    compileSdkVersion 0
-    defaultConfig {
-        minSdkVersion 0
-        targetSdkVersion 27
-        versionCode 1
-        versionName "1.0"
-        multiDexEnabled true
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-    }
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
-    }
-    compileOptions {
-        targetCompatibility 1.8
-        sourceCompatibility 1.8
-    }
-}
-dependencies {
-
-}"""
+        val expected = """
+            android {
+                compileSdkVersion 0
+                defaultConfig {
+                    minSdkVersion 0
+                    targetSdkVersion 27
+                    versionCode 1
+                    versionName "1.0"
+                    multiDexEnabled true
+                    testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+                }
+                buildTypes {
+                    release {
+                        minifyEnabled false
+                        proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+                    }
+                }
+                compileOptions {
+                    targetCompatibility 1.8
+                    sourceCompatibility 1.8
+                }
+            }
+            dependencies {
+            
+            }""".trimIndent()
         verify(fileWriter).writeToFile(expected, "path")
     }
 
@@ -144,32 +148,33 @@ dependencies {
                 LibraryDependency("kapt", "library3")
         ))
         androidModuleBuildGradleGenerator.generate(blueprint)
-        val expected = """android {
-    compileSdkVersion 0
-    defaultConfig {
-        minSdkVersion 0
-        targetSdkVersion 0
-        versionCode 1
-        versionName "1.0"
-        multiDexEnabled true
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-    }
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
-    }
-    compileOptions {
-        targetCompatibility 1.8
-        sourceCompatibility 1.8
-    }
-}
-dependencies {
-    implementation "library1"
-    testApi "library2"
-    kapt "library3"
-}"""
+        val expected = """
+            android {
+                compileSdkVersion 0
+                defaultConfig {
+                    minSdkVersion 0
+                    targetSdkVersion 0
+                    versionCode 1
+                    versionName "1.0"
+                    multiDexEnabled true
+                    testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+                }
+                buildTypes {
+                    release {
+                        minifyEnabled false
+                        proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+                    }
+                }
+                compileOptions {
+                    targetCompatibility 1.8
+                    sourceCompatibility 1.8
+                }
+            }
+            dependencies {
+                implementation "library1"
+                testApi "library2"
+                kapt "library3"
+            }""".trimIndent()
         verify(fileWriter).writeToFile(expected, "path")
     }
 
@@ -179,39 +184,40 @@ dependencies {
                 flavorDimensions = setOf("dim1", "dim2", "dim3"),
                 productFlavors = setOf(Flavor("flav1", "dim1"), Flavor("flav2")))
         androidModuleBuildGradleGenerator.generate(blueprint)
-        val expected = """android {
-    compileSdkVersion 0
-    defaultConfig {
-        minSdkVersion 0
-        targetSdkVersion 0
-        versionCode 1
-        versionName "1.0"
-        multiDexEnabled true
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-    }
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
-    }
-    compileOptions {
-        targetCompatibility 1.8
-        sourceCompatibility 1.8
-    }
-    flavorDimensions "dim1", "dim2", "dim3"
-    productFlavors {
-        flav1 {
-            dimension "dim1"
-        }
-        flav2 {
-
-        }
-    }
-}
-dependencies {
-
-}"""
+        val expected = """
+            android {
+                compileSdkVersion 0
+                defaultConfig {
+                    minSdkVersion 0
+                    targetSdkVersion 0
+                    versionCode 1
+                    versionName "1.0"
+                    multiDexEnabled true
+                    testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+                }
+                buildTypes {
+                    release {
+                        minifyEnabled false
+                        proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+                    }
+                }
+                compileOptions {
+                    targetCompatibility 1.8
+                    sourceCompatibility 1.8
+                }
+                flavorDimensions "dim1", "dim2", "dim3"
+                productFlavors {
+                    flav1 {
+                        dimension "dim1"
+                    }
+                    flav2 {
+            
+                    }
+                }
+            }
+            dependencies {
+            
+            }""".trimIndent()
         verify(fileWriter).writeToFile(expected, "path")
     }
 
@@ -222,37 +228,38 @@ dependencies {
                 BuildType("buildType2", "line1\nline2")
         ))
         androidModuleBuildGradleGenerator.generate(blueprint)
-        val expected = """android {
-    compileSdkVersion 0
-    defaultConfig {
-        minSdkVersion 0
-        targetSdkVersion 0
-        versionCode 1
-        versionName "1.0"
-        multiDexEnabled true
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-    }
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
-        buildType1 {
-
-        }
-        buildType2 {
-            line1
-            line2
-        }
-    }
-    compileOptions {
-        targetCompatibility 1.8
-        sourceCompatibility 1.8
-    }
-}
-dependencies {
-
-}"""
+        val expected = """
+            android {
+                compileSdkVersion 0
+                defaultConfig {
+                    minSdkVersion 0
+                    targetSdkVersion 0
+                    versionCode 1
+                    versionName "1.0"
+                    multiDexEnabled true
+                    testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+                }
+                buildTypes {
+                    release {
+                        minifyEnabled false
+                        proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+                    }
+                    buildType1 {
+            
+                    }
+                    buildType2 {
+                        line1
+                        line2
+                    }
+                }
+                compileOptions {
+                    targetCompatibility 1.8
+                    sourceCompatibility 1.8
+                }
+            }
+            dependencies {
+            
+            }""".trimIndent()
         verify(fileWriter).writeToFile(expected, "path")
     }
 
@@ -262,34 +269,35 @@ dependencies {
                 GradleTask("task1", listOf("line1", "line2"))
         ))
         androidModuleBuildGradleGenerator.generate(blueprint)
-        val expected = """android {
-    compileSdkVersion 0
-    defaultConfig {
-        minSdkVersion 0
-        targetSdkVersion 0
-        versionCode 1
-        versionName "1.0"
-        multiDexEnabled true
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-    }
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
-    }
-    compileOptions {
-        targetCompatibility 1.8
-        sourceCompatibility 1.8
-    }
-}
-dependencies {
-
-}
-task1 {
-    line1
-    line2
-}"""
+        val expected = """
+            android {
+                compileSdkVersion 0
+                defaultConfig {
+                    minSdkVersion 0
+                    targetSdkVersion 0
+                    versionCode 1
+                    versionName "1.0"
+                    multiDexEnabled true
+                    testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+                }
+                buildTypes {
+                    release {
+                        minifyEnabled false
+                        proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+                    }
+                }
+                compileOptions {
+                    targetCompatibility 1.8
+                    sourceCompatibility 1.8
+                }
+            }
+            dependencies {
+            
+            }
+            task1 {
+                line1
+                line2
+            }""".trimIndent()
         verify(fileWriter).writeToFile(expected, "path")
     }
 

--- a/aspoet/src/test/kotlin/com/google/androidstudiopoet/models/AndroidBuildGradleBlueprintTest.kt
+++ b/aspoet/src/test/kotlin/com/google/androidstudiopoet/models/AndroidBuildGradleBlueprintTest.kt
@@ -238,6 +238,7 @@ class AndroidBuildGradleBlueprintTest {
 
     private fun createAndroidBuildGradleBlueprint(isApplication: Boolean = false,
                                                   enableKotlin: Boolean = false,
+                                                  enableCompose: Boolean = false,
                                                   enableDataBinding: Boolean = false,
                                                   moduleRoot: String = "",
                                                   androidBuildConfig: AndroidBuildConfig = AndroidBuildConfig(),
@@ -247,6 +248,6 @@ class AndroidBuildGradleBlueprintTest {
                                                   buildTypeConfigs: List<BuildTypeConfig>? = null,
                                                   dependencies: Set<ModuleDependency> = setOf(),
                                                   pluginConfigs: List<PluginConfig>? = null
-    ) = AndroidBuildGradleBlueprint(isApplication, enableKotlin, enableDataBinding, moduleRoot, androidBuildConfig,
+    ) = AndroidBuildGradleBlueprint(isApplication, enableKotlin, enableCompose, enableDataBinding, moduleRoot, androidBuildConfig,
             packageName, extraLines, productFlavorConfigs, buildTypeConfigs, dependencies, pluginConfigs)
 }

--- a/aspoet/src/test/kotlin/com/google/androidstudiopoet/models/AndroidModuleBlueprintTest.kt
+++ b/aspoet/src/test/kotlin/com/google/androidstudiopoet/models/AndroidModuleBlueprintTest.kt
@@ -23,12 +23,13 @@ class AndroidModuleBlueprintTest {
         val androidModuleBlueprint = getAndroidModuleBlueprint()
 
         assertThat(androidModuleBlueprint.activityBlueprints).isEqualTo(listOf(ActivityBlueprint(
-                    "Activity0",
-                    androidModuleBlueprint.resourcesBlueprint!!.layoutBlueprints[0],
-                    androidModuleBlueprint.packagePath,
-                    androidModuleBlueprint.packageName,
-                    androidModuleBlueprint.packagesBlueprint.javaPackageBlueprints[0].classBlueprints[0],
-                    listOf(), false)))
+                "Activity0",
+                false,
+                androidModuleBlueprint.resourcesBlueprint!!.layoutBlueprints[0],
+                androidModuleBlueprint.packagePath,
+                androidModuleBlueprint.packageName,
+                androidModuleBlueprint.packagesBlueprint.javaPackageBlueprints[0].classBlueprints[0],
+                listOf(), false)))
     }
 
     @Test
@@ -50,31 +51,59 @@ class AndroidModuleBlueprintTest {
     }
 
     @Test
-    fun `hasDataBinding is false when data binding config is null`() {
+    fun `enableDataBinding is false when data binding config is null`() {
         val androidModuleBlueprint = getAndroidModuleBlueprint(dataBindingConfig = null)
 
-        androidModuleBlueprint.hasDataBinding.assertFalse()
+        androidModuleBlueprint.enableDataBinding.assertFalse()
     }
 
     @Test
-    fun `hasDataBinding is false when data binding config has zero listener count`() {
+    fun `enableDataBinding is false when data binding config has zero listener count`() {
         val androidModuleBlueprint = getAndroidModuleBlueprint(dataBindingConfig = DataBindingConfig(listenerCount = 0))
 
-        androidModuleBlueprint.hasDataBinding.assertFalse()
+        androidModuleBlueprint.enableDataBinding.assertFalse()
     }
 
     @Test
-    fun `hasDataBinding is true when data binding config has positive listener count`() {
+    fun `enableDataBinding is true when data binding config has positive listener count`() {
         val androidModuleBlueprint = getAndroidModuleBlueprint(dataBindingConfig = DataBindingConfig(listenerCount = 2))
 
-        androidModuleBlueprint.hasDataBinding.assertTrue()
+        androidModuleBlueprint.enableDataBinding.assertTrue()
     }
 
     @Test
-    fun `hasDataBinding is false when data binding config has negative listener count`() {
+    fun `enableDataBinding is false when data binding config has negative listener count`() {
         val androidModuleBlueprint = getAndroidModuleBlueprint(dataBindingConfig = DataBindingConfig(listenerCount = -1))
 
-        androidModuleBlueprint.hasDataBinding.assertFalse()
+        androidModuleBlueprint.enableDataBinding.assertFalse()
+    }
+
+    @Test
+    fun `enableCompose is false when compose config is null`() {
+        val androidModuleBlueprint = getAndroidModuleBlueprint(composeConfig = null)
+
+        androidModuleBlueprint.enableCompose.assertFalse()
+    }
+
+    @Test
+    fun `enableCompose is false when compose config has zero action count`() {
+        val androidModuleBlueprint = getAndroidModuleBlueprint(composeConfig = ComposeConfig(actionCount = 0))
+
+        androidModuleBlueprint.enableCompose.assertFalse()
+    }
+
+    @Test
+    fun `enableCompose is true when compose config has positive action count`() {
+        val androidModuleBlueprint = getAndroidModuleBlueprint(composeConfig = ComposeConfig(actionCount = 2))
+
+        androidModuleBlueprint.enableCompose.assertTrue()
+    }
+
+    @Test
+    fun `enableCompose is false when compose config has negative action count`() {
+        val androidModuleBlueprint = getAndroidModuleBlueprint(composeConfig = ComposeConfig(actionCount = -1))
+
+        androidModuleBlueprint.enableCompose.assertFalse()
     }
 
     @Test
@@ -99,12 +128,13 @@ class AndroidModuleBlueprintTest {
             extraLines: List<String>? = null,
             generateTests: Boolean = true,
             dataBindingConfig: DataBindingConfig? = null,
+            composeConfig: ComposeConfig? = null,
             androidBuildConfig: AndroidBuildConfig = AndroidBuildConfig(),
             pluginConfigs: List<PluginConfig>? = null,
             generateBazelFiles: Boolean? = false
     ) = AndroidModuleBlueprint(name, numOfActivities, resourcesConfig, projectRoot, hasLaunchActivity, useKotlin,
             dependencies, productFlavorConfigs, buildTypeConfigs, javaConfig, kotlinConfig,
-            extraLines, generateTests, dataBindingConfig, androidBuildConfig, pluginConfigs, generateBazelFiles)
+            extraLines, generateTests, dataBindingConfig, composeConfig, androidBuildConfig, pluginConfigs, generateBazelFiles)
 
     private fun defaultCodeConfig() = CodeConfig().apply {
         packages = 1

--- a/configs/compose/compose.json
+++ b/configs/compose/compose.json
@@ -1,0 +1,264 @@
+{
+  "inputVersion": "0.1",
+  "projectConfig": {
+    "projectName": "composeProject",
+    "root": "../generated_projects/compose",
+    "buildSystemConfig": {
+      "buildSystemVersion": "7.2",
+      "agpVersion": "7.0.2",
+      "kotlinVersion": "1.5.31"
+    },
+    "moduleConfigs": [
+      {
+        "moduleType": "android",
+        "androidBuildConfig": {
+          "minSdkVersion": 24
+        },
+        "kotlin": {
+          "packages": 4,
+          "classesPerPackage": 10,
+          "methodsPerClass": 10
+        },
+        "useKotlin": true,
+        "moduleName": "applicationModule",
+        "activityCount": 5,
+        "hasLaunchActivity": true,
+        "resourcesConfig": {
+          "stringCount": 5,
+          "imageCount": 5,
+          "layoutCount": 5
+        },
+        "composeConfig": {
+          "onClickCount": 5
+        },
+        "dependencies": [
+          {
+            "moduleName": "libraryModule"
+          },
+          {
+            "moduleName": "libraryModule1"
+          },
+          {
+            "moduleName": "libraryModule2"
+          },
+          {
+            "moduleName": "libraryModule3"
+          },
+          {
+            "moduleName": "libraryModule4"
+          },
+          {
+            "moduleName": "libraryModule5"
+          },
+          {
+            "moduleName": "libraryModule6"
+          },
+          {
+            "moduleName": "libraryModule7"
+          },
+          {
+            "moduleName": "libraryModule8"
+          }
+        ]
+      },
+      {
+        "moduleType": "android",
+        "androidBuildConfig": {
+          "minSdkVersion": 24
+        },
+        "kotlin": {
+          "packages": 4,
+          "classesPerPackage": 10,
+          "methodsPerClass": 10
+        },
+        "useKotlin": true,
+        "moduleName": "libraryModule",
+        "activityCount": 5,
+        "resourcesConfig": {
+          "stringCount": 5,
+          "imageCount": 5,
+          "layoutCount": 5
+        },
+        "composeConfig": {
+          "onClickCount": 5
+        }
+      },
+      {
+        "moduleType": "android",
+        "androidBuildConfig": {
+          "minSdkVersion": 24
+        },
+        "kotlin": {
+          "packages": 4,
+          "classesPerPackage": 10,
+          "methodsPerClass": 10
+        },
+        "useKotlin": true,
+        "moduleName": "libraryModule1",
+        "activityCount": 5,
+        "resourcesConfig": {
+          "stringCount": 5,
+          "imageCount": 5,
+          "layoutCount": 5
+        },
+        "composeConfig": {
+          "onClickCount": 5
+        }
+      },
+      {
+        "moduleType": "android",
+        "androidBuildConfig": {
+          "minSdkVersion": 24
+        },
+        "kotlin": {
+          "packages": 4,
+          "classesPerPackage": 10,
+          "methodsPerClass": 10
+        },
+        "useKotlin": true,
+        "moduleName": "libraryModule2",
+        "activityCount": 5,
+        "resourcesConfig": {
+          "stringCount": 5,
+          "imageCount": 5,
+          "layoutCount": 5
+        },
+        "composeConfig": {
+          "onClickCount": 5
+        }
+      },
+      {
+        "moduleType": "android",
+        "androidBuildConfig": {
+          "minSdkVersion": 24
+        },
+        "kotlin": {
+          "packages": 4,
+          "classesPerPackage": 10,
+          "methodsPerClass": 10
+        },
+        "useKotlin": true,
+        "moduleName": "libraryModule3",
+        "activityCount": 5,
+        "resourcesConfig": {
+          "stringCount": 5,
+          "imageCount": 5,
+          "layoutCount": 5
+        },
+        "composeConfig": {
+          "onClickCount": 5
+        }
+      },
+      {
+        "moduleType": "android",
+        "androidBuildConfig": {
+          "minSdkVersion": 24
+        },
+        "kotlin": {
+          "packages": 4,
+          "classesPerPackage": 10,
+          "methodsPerClass": 10
+        },
+        "useKotlin": true,
+        "moduleName": "libraryModule4",
+        "activityCount": 5,
+        "resourcesConfig": {
+          "stringCount": 5,
+          "imageCount": 5,
+          "layoutCount": 5
+        },
+        "composeConfig": {
+          "onClickCount": 5
+        }
+      },
+      {
+        "moduleType": "android",
+        "androidBuildConfig": {
+          "minSdkVersion": 24
+        },
+        "kotlin": {
+          "packages": 4,
+          "classesPerPackage": 10,
+          "methodsPerClass": 10
+        },
+        "useKotlin": true,
+        "moduleName": "libraryModule5",
+        "activityCount": 5,
+        "resourcesConfig": {
+          "stringCount": 5,
+          "imageCount": 5,
+          "layoutCount": 5
+        },
+        "composeConfig": {
+          "onClickCount": 5
+        }
+      },
+      {
+        "moduleType": "android",
+        "androidBuildConfig": {
+          "minSdkVersion": 24
+        },
+        "kotlin": {
+          "packages": 4,
+          "classesPerPackage": 10,
+          "methodsPerClass": 10
+        },
+        "useKotlin": true,
+        "moduleName": "libraryModule6",
+        "activityCount": 5,
+        "resourcesConfig": {
+          "stringCount": 5,
+          "imageCount": 5,
+          "layoutCount": 5
+        },
+        "composeConfig": {
+          "onClickCount": 5
+        }
+      },
+      {
+        "moduleType": "android",
+        "androidBuildConfig": {
+          "minSdkVersion": 24
+        },
+        "kotlin": {
+          "packages": 4,
+          "classesPerPackage": 10,
+          "methodsPerClass": 10
+        },
+        "useKotlin": true,
+        "moduleName": "libraryModule7",
+        "activityCount": 5,
+        "resourcesConfig": {
+          "stringCount": 5,
+          "imageCount": 5,
+          "layoutCount": 5
+        },
+        "composeConfig": {
+          "onClickCount": 5
+        }
+      },
+      {
+        "moduleType": "android",
+        "androidBuildConfig": {
+          "minSdkVersion": 24
+        },
+        "kotlin": {
+          "packages": 4,
+          "classesPerPackage": 10,
+          "methodsPerClass": 10
+        },
+        "useKotlin": true,
+        "moduleName": "libraryModule8",
+        "activityCount": 5,
+        "resourcesConfig": {
+          "stringCount": 5,
+          "imageCount": 5,
+          "layoutCount": 5
+        },
+        "composeConfig": {
+          "onClickCount": 5
+        }
+      }
+    ]
+  }
+}

--- a/configs/compose/databinding.json
+++ b/configs/compose/databinding.json
@@ -1,0 +1,264 @@
+{
+  "inputVersion": "0.1",
+  "projectConfig": {
+    "projectName": "dataBindingProject",
+    "root": "../generated_projects/compose",
+    "buildSystemConfig": {
+      "buildSystemVersion": "7.2",
+      "agpVersion": "7.0.2",
+      "kotlinVersion": "1.5.31"
+    },
+    "moduleConfigs": [
+      {
+        "moduleType": "android",
+        "androidBuildConfig": {
+          "minSdkVersion": 24
+        },
+        "kotlin": {
+          "packages": 4,
+          "classesPerPackage": 10,
+          "methodsPerClass": 10
+        },
+        "useKotlin": true,
+        "moduleName": "applicationModule",
+        "activityCount": 5,
+        "hasLaunchActivity": true,
+        "resourcesConfig": {
+          "stringCount": 5,
+          "imageCount": 5,
+          "layoutCount": 5
+        },
+        "dataBindingConfig": {
+          "listenerCount": 5
+        },
+        "dependencies": [
+          {
+            "moduleName": "libraryModule"
+          },
+          {
+            "moduleName": "libraryModule1"
+          },
+          {
+            "moduleName": "libraryModule2"
+          },
+          {
+            "moduleName": "libraryModule3"
+          },
+          {
+            "moduleName": "libraryModule4"
+          },
+          {
+            "moduleName": "libraryModule5"
+          },
+          {
+            "moduleName": "libraryModule6"
+          },
+          {
+            "moduleName": "libraryModule7"
+          },
+          {
+            "moduleName": "libraryModule8"
+          }
+        ]
+      },
+      {
+        "moduleType": "android",
+        "androidBuildConfig": {
+          "minSdkVersion": 24
+        },
+        "kotlin": {
+          "packages": 4,
+          "classesPerPackage": 10,
+          "methodsPerClass": 10
+        },
+        "useKotlin": true,
+        "moduleName": "libraryModule",
+        "activityCount": 5,
+        "resourcesConfig": {
+          "stringCount": 5,
+          "imageCount": 5,
+          "layoutCount": 5
+        },
+        "dataBindingConfig": {
+          "listenerCount": 5
+        }
+      },
+      {
+        "moduleType": "android",
+        "androidBuildConfig": {
+          "minSdkVersion": 24
+        },
+        "kotlin": {
+          "packages": 4,
+          "classesPerPackage": 10,
+          "methodsPerClass": 10
+        },
+        "useKotlin": true,
+        "moduleName": "libraryModule1",
+        "activityCount": 5,
+        "resourcesConfig": {
+          "stringCount": 5,
+          "imageCount": 5,
+          "layoutCount": 5
+        },
+        "dataBindingConfig": {
+          "listenerCount": 5
+        }
+      },
+      {
+        "moduleType": "android",
+        "androidBuildConfig": {
+          "minSdkVersion": 24
+        },
+        "kotlin": {
+          "packages": 4,
+          "classesPerPackage": 10,
+          "methodsPerClass": 10
+        },
+        "useKotlin": true,
+        "moduleName": "libraryModule2",
+        "activityCount": 5,
+        "resourcesConfig": {
+          "stringCount": 5,
+          "imageCount": 5,
+          "layoutCount": 5
+        },
+        "dataBindingConfig": {
+          "listenerCount": 5
+        }
+      },
+      {
+        "moduleType": "android",
+        "androidBuildConfig": {
+          "minSdkVersion": 24
+        },
+        "kotlin": {
+          "packages": 4,
+          "classesPerPackage": 10,
+          "methodsPerClass": 10
+        },
+        "useKotlin": true,
+        "moduleName": "libraryModule3",
+        "activityCount": 5,
+        "resourcesConfig": {
+          "stringCount": 5,
+          "imageCount": 5,
+          "layoutCount": 5
+        },
+        "dataBindingConfig": {
+          "listenerCount": 5
+        }
+      },
+      {
+        "moduleType": "android",
+        "androidBuildConfig": {
+          "minSdkVersion": 24
+        },
+        "kotlin": {
+          "packages": 4,
+          "classesPerPackage": 10,
+          "methodsPerClass": 10
+        },
+        "useKotlin": true,
+        "moduleName": "libraryModule4",
+        "activityCount": 5,
+        "resourcesConfig": {
+          "stringCount": 5,
+          "imageCount": 5,
+          "layoutCount": 5
+        },
+        "dataBindingConfig": {
+          "listenerCount": 5
+        }
+      },
+      {
+        "moduleType": "android",
+        "androidBuildConfig": {
+          "minSdkVersion": 24
+        },
+        "kotlin": {
+          "packages": 4,
+          "classesPerPackage": 10,
+          "methodsPerClass": 10
+        },
+        "useKotlin": true,
+        "moduleName": "libraryModule5",
+        "activityCount": 5,
+        "resourcesConfig": {
+          "stringCount": 5,
+          "imageCount": 5,
+          "layoutCount": 5
+        },
+        "dataBindingConfig": {
+          "listenerCount": 5
+        }
+      },
+      {
+        "moduleType": "android",
+        "androidBuildConfig": {
+          "minSdkVersion": 24
+        },
+        "kotlin": {
+          "packages": 4,
+          "classesPerPackage": 10,
+          "methodsPerClass": 10
+        },
+        "useKotlin": true,
+        "moduleName": "libraryModule6",
+        "activityCount": 5,
+        "resourcesConfig": {
+          "stringCount": 5,
+          "imageCount": 5,
+          "layoutCount": 5
+        },
+        "dataBindingConfig": {
+          "listenerCount": 5
+        }
+      },
+      {
+        "moduleType": "android",
+        "androidBuildConfig": {
+          "minSdkVersion": 24
+        },
+        "kotlin": {
+          "packages": 4,
+          "classesPerPackage": 10,
+          "methodsPerClass": 10
+        },
+        "useKotlin": true,
+        "moduleName": "libraryModule7",
+        "activityCount": 5,
+        "resourcesConfig": {
+          "stringCount": 5,
+          "imageCount": 5,
+          "layoutCount": 5
+        },
+        "dataBindingConfig": {
+          "listenerCount": 5
+        }
+      },
+      {
+        "moduleType": "android",
+        "androidBuildConfig": {
+          "minSdkVersion": 24
+        },
+        "kotlin": {
+          "packages": 4,
+          "classesPerPackage": 10,
+          "methodsPerClass": 10
+        },
+        "useKotlin": true,
+        "moduleName": "libraryModule8",
+        "activityCount": 5,
+        "resourcesConfig": {
+          "stringCount": 5,
+          "imageCount": 5,
+          "layoutCount": 5
+        },
+        "dataBindingConfig": {
+          "listenerCount": 5
+        }
+      }
+    ]
+  }
+}

--- a/configs/compose/plain.json
+++ b/configs/compose/plain.json
@@ -1,0 +1,234 @@
+{
+  "inputVersion": "0.1",
+  "projectConfig": {
+    "projectName": "plainProject",
+    "root": "../generated_projects/compose",
+    "buildSystemConfig": {
+      "buildSystemVersion": "7.2",
+      "agpVersion": "7.0.2",
+      "kotlinVersion": "1.5.31"
+    },
+    "moduleConfigs": [
+      {
+        "moduleType": "android",
+        "androidBuildConfig": {
+          "minSdkVersion": 24
+        },
+        "kotlin": {
+          "packages": 4,
+          "classesPerPackage": 10,
+          "methodsPerClass": 10
+        },
+        "useKotlin": true,
+        "moduleName": "applicationModule",
+        "activityCount": 5,
+        "hasLaunchActivity": true,
+        "resourcesConfig": {
+          "stringCount": 5,
+          "imageCount": 5,
+          "layoutCount": 5
+        },
+        "dependencies": [
+          {
+            "moduleName": "libraryModule"
+          },
+          {
+            "moduleName": "libraryModule1"
+          },
+          {
+            "moduleName": "libraryModule2"
+          },
+          {
+            "moduleName": "libraryModule3"
+          },
+          {
+            "moduleName": "libraryModule4"
+          },
+          {
+            "moduleName": "libraryModule5"
+          },
+          {
+            "moduleName": "libraryModule6"
+          },
+          {
+            "moduleName": "libraryModule7"
+          },
+          {
+            "moduleName": "libraryModule8"
+          }
+        ]
+      },
+      {
+        "moduleType": "android",
+        "androidBuildConfig": {
+          "minSdkVersion": 24
+        },
+        "kotlin": {
+          "packages": 4,
+          "classesPerPackage": 10,
+          "methodsPerClass": 10
+        },
+        "useKotlin": true,
+        "moduleName": "libraryModule",
+        "activityCount": 5,
+        "resourcesConfig": {
+          "stringCount": 5,
+          "imageCount": 5,
+          "layoutCount": 5
+        }
+      },
+      {
+        "moduleType": "android",
+        "androidBuildConfig": {
+          "minSdkVersion": 24
+        },
+        "kotlin": {
+          "packages": 4,
+          "classesPerPackage": 10,
+          "methodsPerClass": 10
+        },
+        "useKotlin": true,
+        "moduleName": "libraryModule1",
+        "activityCount": 5,
+        "resourcesConfig": {
+          "stringCount": 5,
+          "imageCount": 5,
+          "layoutCount": 5
+        }
+      },
+      {
+        "moduleType": "android",
+        "androidBuildConfig": {
+          "minSdkVersion": 24
+        },
+        "kotlin": {
+          "packages": 4,
+          "classesPerPackage": 10,
+          "methodsPerClass": 10
+        },
+        "useKotlin": true,
+        "moduleName": "libraryModule2",
+        "activityCount": 5,
+        "resourcesConfig": {
+          "stringCount": 5,
+          "imageCount": 5,
+          "layoutCount": 5
+        }
+      },
+      {
+        "moduleType": "android",
+        "androidBuildConfig": {
+          "minSdkVersion": 24
+        },
+        "kotlin": {
+          "packages": 4,
+          "classesPerPackage": 10,
+          "methodsPerClass": 10
+        },
+        "useKotlin": true,
+        "moduleName": "libraryModule3",
+        "activityCount": 5,
+        "resourcesConfig": {
+          "stringCount": 5,
+          "imageCount": 5,
+          "layoutCount": 5
+        }
+      },
+      {
+        "moduleType": "android",
+        "androidBuildConfig": {
+          "minSdkVersion": 24
+        },
+        "kotlin": {
+          "packages": 4,
+          "classesPerPackage": 10,
+          "methodsPerClass": 10
+        },
+        "useKotlin": true,
+        "moduleName": "libraryModule4",
+        "activityCount": 5,
+        "resourcesConfig": {
+          "stringCount": 5,
+          "imageCount": 5,
+          "layoutCount": 5
+        }
+      },
+      {
+        "moduleType": "android",
+        "androidBuildConfig": {
+          "minSdkVersion": 24
+        },
+        "kotlin": {
+          "packages": 4,
+          "classesPerPackage": 10,
+          "methodsPerClass": 10
+        },
+        "useKotlin": true,
+        "moduleName": "libraryModule5",
+        "activityCount": 5,
+        "resourcesConfig": {
+          "stringCount": 5,
+          "imageCount": 5,
+          "layoutCount": 5
+        }
+      },
+      {
+        "moduleType": "android",
+        "androidBuildConfig": {
+          "minSdkVersion": 24
+        },
+        "kotlin": {
+          "packages": 4,
+          "classesPerPackage": 10,
+          "methodsPerClass": 10
+        },
+        "useKotlin": true,
+        "moduleName": "libraryModule6",
+        "activityCount": 5,
+        "resourcesConfig": {
+          "stringCount": 5,
+          "imageCount": 5,
+          "layoutCount": 5
+        }
+      },
+      {
+        "moduleType": "android",
+        "androidBuildConfig": {
+          "minSdkVersion": 24
+        },
+        "kotlin": {
+          "packages": 4,
+          "classesPerPackage": 10,
+          "methodsPerClass": 10
+        },
+        "useKotlin": true,
+        "moduleName": "libraryModule7",
+        "activityCount": 5,
+        "resourcesConfig": {
+          "stringCount": 5,
+          "imageCount": 5,
+          "layoutCount": 5
+        }
+      },
+      {
+        "moduleType": "android",
+        "androidBuildConfig": {
+          "minSdkVersion": 24
+        },
+        "kotlin": {
+          "packages": 4,
+          "classesPerPackage": 10,
+          "methodsPerClass": 10
+        },
+        "useKotlin": true,
+        "moduleName": "libraryModule8",
+        "activityCount": 5,
+        "resourcesConfig": {
+          "stringCount": 5,
+          "imageCount": 5,
+          "layoutCount": 5
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- The compose variant will be equivalent to data binding. `Modifier.onClick` will be set for `Text()` and `Image()` composeables if we specify actions.

## Test
I added several configs under `configs/compose/` and verify that the generated project can be installed and run without modification.