### PR TITLE
Add referring composable function from outside modules

### DIFF
--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/android_modules/KotlinActivityGenerator.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/android_modules/KotlinActivityGenerator.kt
@@ -121,9 +121,9 @@ class KotlinActivityGenerator(var fileWriter: FileWriter): ActivityGenerator {
                 }
             }
             builder.endControlFlow()
-            layout.layoutsToInclude.forEach { screenFunctionFqcn ->
-                val packageName = screenFunctionFqcn.substring(0, screenFunctionFqcn.lastIndexOf('.'))
-                val functionName = screenFunctionFqcn.substring(1 + screenFunctionFqcn.lastIndexOf('.'))
+            layout.layoutsToInclude.forEach { screenFunctionFullQualifiedName ->
+                val packageName = screenFunctionFullQualifiedName.substring(0, screenFunctionFullQualifiedName.lastIndexOf('.'))
+                val functionName = screenFunctionFullQualifiedName.substring(1 + screenFunctionFullQualifiedName.lastIndexOf('.'))
                 builder.addStatement("%M()", MemberName(packageName, functionName))
             }
             return builder.build()

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/android_modules/KotlinActivityGenerator.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/android_modules/KotlinActivityGenerator.kt
@@ -81,9 +81,8 @@ class KotlinActivityGenerator(var fileWriter: FileWriter): ActivityGenerator {
             val modifier = ClassName("androidx.compose.ui", "Modifier")
             val painterResource = MemberName("androidx.compose.ui.res", "painterResource")
             val stringResource = MemberName("androidx.compose.ui.res", "stringResource")
-            val builder = FunSpec.builder("Screen")
+            val builder = FunSpec.builder("${className}Screen")
                     .addAnnotation(ClassName("androidx.compose.runtime", "Composable"))
-                    .addModifiers(KModifier.PRIVATE)
                     .addStatement("val scrollState = %M()", rememberScrollableState)
                     .beginControlFlow("%M(modifier = %T.%M(scrollState))", column, modifier, verticalScroll)
             layout.textViewsBlueprints.forEach { textViewBlueprint ->
@@ -122,6 +121,11 @@ class KotlinActivityGenerator(var fileWriter: FileWriter): ActivityGenerator {
                 }
             }
             builder.endControlFlow()
+            layout.layoutsToInclude.forEach { screenFunctionFqcn ->
+                val packageName = screenFunctionFqcn.substring(0, screenFunctionFqcn.lastIndexOf('.'))
+                val functionName = screenFunctionFqcn.substring(1 + screenFunctionFqcn.lastIndexOf('.'))
+                builder.addStatement("%M()", MemberName(packageName, functionName))
+            }
             return builder.build()
         } else {
             return null
@@ -140,7 +144,7 @@ class KotlinActivityGenerator(var fileWriter: FileWriter): ActivityGenerator {
         if (enableCompose) {
             val setContent = MemberName("androidx.activity.compose", "setContent")
             builder.beginControlFlow("%M", setContent)
-            builder.addStatement("Screen()")
+            builder.addStatement("${className}Screen()")
             builder.endControlFlow()
         } else if (enableDataBinding) {
             val bindingClassName = ClassName.bestGuess(dataBindingClassName)

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/ResourcesBlueprint.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/ResourcesBlueprint.kt
@@ -30,7 +30,13 @@ data class ResourcesBlueprint(private val moduleName: String,
     val stringNames = (0 until stringCount).map { "${moduleName}string$it" }
     val imageNames = (0 until imageCount).map { "${moduleName.toLowerCase()}image$it" }
 
-    val layoutNames = (0 until layoutCount).map { "${moduleName.toLowerCase()}activity_main$it" }
+    val layoutNames = (0 until layoutCount).map {
+        if (enableCompose) {
+            "com.${moduleName}.Activity${it}Screen"
+        } else {
+            "${moduleName.toLowerCase()}activity_main$it"
+        }
+    }
 
     val layoutsDir = resDirPath.joinPath("layout")
 

--- a/configs/compose/gradle-profiler-commands.sh
+++ b/configs/compose/gradle-profiler-commands.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+gradle-profiler --benchmark --project-dir ../generated_projects/compose/composeProject --scenario-file configs/compose/gradle-profiler.scenarios --output-dir profile-compose-clean-build clean_build
+gradle-profiler --benchmark --project-dir ../generated_projects/compose/plainProject --scenario-file configs/compose/gradle-profiler.scenarios --output-dir profile-plain-clean-build clean_build
+gradle-profiler --benchmark --project-dir ../generated_projects/compose/viewBindingProject --scenario-file configs/compose/gradle-profiler.scenarios --output-dir profile-viewbinding-clean-build clean_build
+gradle-profiler --benchmark --project-dir ../generated_projects/compose/dataBindingProject --scenario-file configs/compose/gradle-profiler.scenarios --output-dir profile-databinding-clean-build clean_build
+gradle-profiler --benchmark --project-dir ../generated_projects/compose/dataBindingKaptProject --scenario-file configs/compose/gradle-profiler.scenarios --output-dir profile-databindingkapt-clean-build clean_build
+
+gradle-profiler --benchmark --project-dir ../generated_projects/compose/composeProject --scenario-file configs/compose/gradle-profiler.scenarios --output-dir profile-compose-inc-build compose_inc_build
+gradle-profiler --benchmark --project-dir ../generated_projects/compose/plainProject --scenario-file configs/compose/gradle-profiler.scenarios --output-dir profile-plain-inc-build ui_inc_build
+gradle-profiler --benchmark --project-dir ../generated_projects/compose/viewBindingProject --scenario-file configs/compose/gradle-profiler.scenarios --output-dir profile-viewbinding-inc-build ui_inc_build
+gradle-profiler --benchmark --project-dir ../generated_projects/compose/dataBindingProject --scenario-file configs/compose/gradle-profiler.scenarios --output-dir profile-databinding-inc-build ui_inc_build
+gradle-profiler --benchmark --project-dir ../generated_projects/compose/dataBindingKaptProject --scenario-file configs/compose/gradle-profiler.scenarios --output-dir profile-databindingkapt-inc-build ui_inc_build
+
+gradle-profiler --profile buildscan --project-dir ../generated_projects/compose/composeProject --scenario-file configs/compose/gradle-profiler.scenarios clean_build
+gradle-profiler --profile buildscan --project-dir ../generated_projects/compose/plainProject --scenario-file configs/compose/gradle-profiler.scenarios clean_build
+gradle-profiler --profile buildscan --project-dir ../generated_projects/compose/viewBindingProject --scenario-file configs/compose/gradle-profiler.scenarios clean_build
+gradle-profiler --profile buildscan --project-dir ../generated_projects/compose/dataBindingProject --scenario-file configs/compose/gradle-profiler.scenarios clean_build
+gradle-profiler --profile buildscan --project-dir ../generated_projects/compose/dataBindingKaptProject --scenario-file configs/compose/gradle-profiler.scenarios clean_build
+
+gradle-profiler --profile buildscan --project-dir ../generated_projects/compose/composeProject --scenario-file configs/compose/gradle-profiler.scenarios compose_inc_build
+gradle-profiler --profile buildscan --project-dir ../generated_projects/compose/plainProject --scenario-file configs/compose/gradle-profiler.scenarios ui_inc_build
+gradle-profiler --profile buildscan --project-dir ../generated_projects/compose/viewBindingProject --scenario-file configs/compose/gradle-profiler.scenarios ui_inc_build
+gradle-profiler --profile buildscan --project-dir ../generated_projects/compose/dataBindingProject --scenario-file configs/compose/gradle-profiler.scenarios ui_inc_build
+gradle-profiler --profile buildscan --project-dir ../generated_projects/compose/dataBindingKaptProject --scenario-file configs/compose/gradle-profiler.scenarios ui_inc_build

--- a/configs/compose/gradle-profiler.scenarios
+++ b/configs/compose/gradle-profiler.scenarios
@@ -13,4 +13,5 @@ ui_inc_build {
 compose_inc_build {
     tasks = ["assembleDebug"]
     apply-composable-change-to = "libraryModule/src/main/java/com/libraryModule/Activity4.kt"
+    clear-build-cache-before = SCENARIO
 }

--- a/configs/compose/gradle-profiler.scenarios
+++ b/configs/compose/gradle-profiler.scenarios
@@ -1,0 +1,16 @@
+clean_build {
+    tasks = ["assembleDebug"]
+    cleanup-tasks = ["clean"]
+    gradle-args = ["--no-build-cache"]
+}
+
+ui_inc_build {
+    tasks = ["assembleDebug"]
+    apply-android-layout-change-to = "libraryModule/src/main/res/layout/librarymoduleactivity_main4.xml"
+    clear-build-cache-before = SCENARIO
+}
+
+compose_inc_build {
+    tasks = ["assembleDebug"]
+    apply-composable-change-to = "libraryModule/src/main/java/com/libraryModule/Activity4.kt"
+}


### PR DESCRIPTION
## Summary
The existing `Activity0.kt` in `:applicationModule` has the following content:
```
@Composable
public fun Activity0Screen(): Unit {
  val scrollState = rememberScrollState()
  Column(modifier = Modifier.verticalScroll(scrollState)) {
    Text(text = stringResource(R.string.applicationModulestring0), modifier = Modifier.clickable {
        Foo0().foo9() })
    Image(painter = painterResource(R.drawable.applicationmoduleimage0), contentDescription = null)
  }
}
```
This does not refer layouts from outside modules. This PR fills the gap by adding the equivalent `@Composable` function reference from the outside modules.

Additionally, add gradle-profiler benchmark scenarios and shell commands. One of the gradle profiler scenario uses the mutator `apply-composable-change-to`, which is to be added by https://github.com/gradle/gradle-profiler/pull/357.

## Test
Generated the compose project. The generated project works and the content of `Activity0.kt` in `:applicationModule` now becomes

```
@Composable
public fun Activity0Screen(): Unit {
  val scrollState = rememberScrollState()
  Column(modifier = Modifier.verticalScroll(scrollState)) {
    Text(text = stringResource(R.string.applicationModulestring0), modifier = Modifier.clickable {
        Foo0().foo9() })
    Image(painter = painterResource(R.drawable.applicationmoduleimage0), contentDescription = null)
  }
  Activity4Screen()
  com.libraryModule5.Activity4Screen()
  com.libraryModule.Activity4Screen()
  com.libraryModule7.Activity4Screen()
  com.libraryModule4.Activity4Screen()
  com.libraryModule2.Activity4Screen()
  com.libraryModule1.Activity4Screen()
  com.libraryModule8.Activity4Screen()
  com.libraryModule3.Activity4Screen()
}
```

Although the UI looks strange that all texts and images are stacked together (Otherwise, I am hitting `java.lang.IllegalStateException: Nesting scrollable in the same direction layouts like LazyColumn and Column(Modifier.verticalScroll()) is not allowed. If you want to add a header before the list of items please take a look on LazyColumn component which has a DSL api which allows to first add a header via item() function and then the list of items via items().`).

