### PR TITLE
Update mutator names in compose profiler scenarios

### DIFF
--- a/configs/compose/gradle-profiler.scenarios
+++ b/configs/compose/gradle-profiler.scenarios
@@ -12,6 +12,6 @@ ui_inc_build {
 
 compose_inc_build {
     tasks = ["assembleDebug"]
-    apply-composable-change-to = "libraryModule/src/main/java/com/libraryModule/Activity4.kt"
+    apply-kotlin-composable-change-to = "libraryModule/src/main/java/com/libraryModule/Activity4.kt"
     clear-build-cache-before = SCENARIO
 }


### PR DESCRIPTION
There is a mutator name change requested from https://github.com/gradle/gradle-profiler/pull/357. Updating the scenarios here if other people are interested in rerunning the experiments.

The benchmarking result of Jetpack Compose in build time can be found in https://chao2zhang.medium.com/fairly-evaluating-the-impact-of-different-android-ui-libraries-on-gradle-build-6301de5e0e60