### PR TITLE
Provide a way to attach a mount of library as module deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Create a real life complexity Android project that mimics your own and observe t
 * Configurable version of Gradle, Kotlin, the Android Gradle Plugin
 * Experimental Bazel support
 * [Compose](https://developer.android.com/jetpack/compose) and [DataBinding](https://developer.android.com/topic/libraries/data-binding) support
+* Configurable number of local jar library dependencies
 
 ## Download & Run
 ### IntelliJ IDEA/Android Studio
@@ -56,6 +57,10 @@ will crawl the folder recursively and execute each config in turn.
 * Specify `viewBinding` for View Binding.
 * Specify `composeConfig` for Compose. 
   * It has a property `actionCount` to indicate the number of clickable actions.
+* Sepcify `localJarLibsDependency` for local jar depencencies.
+  * It's a list of items that indicate creating local jar depencencies for specific module. For each item,
+    * It has a property `moduleName` to indicate which module the depencies are attached to.
+    * It has a properoty `count` to indicate how many depencies are attached the specified module.
 * If nothing above is specified, the UI layer code will be traditional XML-based layout.
 * Errors will be thrown when two of the above config is specified.
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ will crawl the folder recursively and execute each config in turn.
   * It has a property `actionCount` to indicate the number of clickable actions.
 * Sepcify `localJarLibsDependency` for local jar depencencies.
   * It's a list of items that indicate creating local jar depencencies for specific module. For each item,
-    * It has a property `moduleName` to indicate which module the depencies are attached to.
-    * It has a properoty `count` to indicate how many depencies are attached the specified module.
+    * It has a property `moduleName` to indicate the module name that depencies are attached to.
+    * It has a properoty `count` to indicate the number of depencies are attached.
 * If nothing above is specified, the UI layer code will be traditional XML-based layout.
 * Errors will be thrown when two of the above config is specified.
 

--- a/aspoet-input/src/main/kotlin/com/google/androidstudiopoet/input/ModuleDependencyConfig.kt
+++ b/aspoet-input/src/main/kotlin/com/google/androidstudiopoet/input/ModuleDependencyConfig.kt
@@ -17,6 +17,15 @@ limitations under the License.
 package com.google.androidstudiopoet.input
 
 sealed class DependencyConfig {
-    data class ModuleDependencyConfig(val moduleName: String, val method: String? = null) : DependencyConfig()
-    data class LibraryDependencyConfig(val library: String, val method: String? = null) : DependencyConfig()
+  data class ModuleDependencyConfig(val moduleName: String, val method: String? = null) :
+    DependencyConfig()
+
+  data class LibraryDependencyConfig(val library: String, val method: String? = null) :
+    DependencyConfig()
+
+  data class DummyLocalJarLibsDependencyConfig(
+    val moduleName: String,
+    val count: Int,
+    val method: String? = null,
+  ) : DependencyConfig()
 }

--- a/aspoet-input/src/main/kotlin/com/google/androidstudiopoet/input/ModuleDependencyConfig.kt
+++ b/aspoet-input/src/main/kotlin/com/google/androidstudiopoet/input/ModuleDependencyConfig.kt
@@ -19,5 +19,5 @@ package com.google.androidstudiopoet.input
 sealed class DependencyConfig {
     data class ModuleDependencyConfig(val moduleName: String, val method: String? = null) : DependencyConfig()
     data class LibraryDependencyConfig(val library: String, val method: String? = null) : DependencyConfig()
-    data class DummyLocalJarLibsDependencyConfig(val moduleName: String, val count: Int, val method: String? = null) : DependencyConfig()
+    data class LocalJarLibsDependencyConfig(val moduleName: String, val count: Int, val method: String? = null) : DependencyConfig()
 }

--- a/aspoet-input/src/main/kotlin/com/google/androidstudiopoet/input/ModuleDependencyConfig.kt
+++ b/aspoet-input/src/main/kotlin/com/google/androidstudiopoet/input/ModuleDependencyConfig.kt
@@ -18,12 +18,6 @@ package com.google.androidstudiopoet.input
 
 sealed class DependencyConfig {
     data class ModuleDependencyConfig(val moduleName: String, val method: String? = null) : DependencyConfig()
-
     data class LibraryDependencyConfig(val library: String, val method: String? = null) : DependencyConfig()
-
-    data class DummyLocalJarLibsDependencyConfig(
-        val moduleName: String,
-        val count: Int,
-        val method: String? = null,
-    ) : DependencyConfig()
+    data class DummyLocalJarLibsDependencyConfig(val moduleName: String, val count: Int, val method: String? = null) : DependencyConfig()
 }

--- a/aspoet-input/src/main/kotlin/com/google/androidstudiopoet/input/ModuleDependencyConfig.kt
+++ b/aspoet-input/src/main/kotlin/com/google/androidstudiopoet/input/ModuleDependencyConfig.kt
@@ -17,15 +17,13 @@ limitations under the License.
 package com.google.androidstudiopoet.input
 
 sealed class DependencyConfig {
-  data class ModuleDependencyConfig(val moduleName: String, val method: String? = null) :
-    DependencyConfig()
+    data class ModuleDependencyConfig(val moduleName: String, val method: String? = null) : DependencyConfig()
 
-  data class LibraryDependencyConfig(val library: String, val method: String? = null) :
-    DependencyConfig()
+    data class LibraryDependencyConfig(val library: String, val method: String? = null) : DependencyConfig()
 
-  data class DummyLocalJarLibsDependencyConfig(
-    val moduleName: String,
-    val count: Int,
-    val method: String? = null,
-  ) : DependencyConfig()
+    data class DummyLocalJarLibsDependencyConfig(
+        val moduleName: String,
+        val count: Int,
+        val method: String? = null,
+    ) : DependencyConfig()
 }

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/ModuleBlueprintFactory.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/ModuleBlueprintFactory.kt
@@ -116,7 +116,7 @@ object ModuleBlueprintFactory {
                             }
                         }
                         is DependencyConfig.LibraryDependencyConfig -> LibraryDependency(dependencyConfig.method.toDependencyMethod(), dependencyConfig.library)
-                        is DependencyConfig.DummyLocalJarLibsDependencyConfig ->  FileTreeDependency(dependencyConfig.method.toDependencyMethod(), "libs", "*.jar", dependencyConfig.count)
+                        is DependencyConfig.LocalJarLibsDependencyConfig ->  FileTreeDependency(dependencyConfig.method.toDependencyMethod(), "libs", "*.jar", dependencyConfig.count)
                     }
                 } ?: listOf()
         return moduleDependencies.toHashSet()

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/ModuleBlueprintFactory.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/ModuleBlueprintFactory.kt
@@ -116,6 +116,7 @@ object ModuleBlueprintFactory {
                             }
                         }
                         is DependencyConfig.LibraryDependencyConfig -> LibraryDependency(dependencyConfig.method.toDependencyMethod(), dependencyConfig.library)
+                        is DependencyConfig.DummyLocalJarLibsDependencyConfig ->  FileTreeDependency(dependencyConfig.method.toDependencyMethod(), "libs", "*.jar", dependencyConfig.count)
                     }
                 } ?: listOf()
         return moduleDependencies.toHashSet()

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToAndroidModuleConfigConverter.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToAndroidModuleConfigConverter.kt
@@ -46,8 +46,8 @@ class ConfigPojoToAndroidModuleConfigConverter {
 
             val resolvedDependencies = config.resolvedDependencies[moduleName]?.sortedBy { it.to }
                     ?.map { dependency -> DependencyConfig.ModuleDependencyConfig(dependency.to, dependency.method) } ?: emptyList()
-            val resolvedDummyLocalJarLibsDependency = config.resolvedDummyLocalJarLibsDependencies[moduleName]?.let { listOf(it) } ?: emptyList()
-            dependencies = (config.libraries?: emptyList()) + resolvedDependencies + resolvedDummyLocalJarLibsDependency
+            val resolvedLocalJarLibsDependency = config.resolvedLocalJarLibsDependencies[moduleName]?.let { listOf(it) } ?: emptyList()
+            dependencies = (config.libraries?: emptyList()) + resolvedDependencies + resolvedLocalJarLibsDependency
 
             this.buildTypes = buildTypes
             this.productFlavorConfigs = productFlavorConfigs

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToAndroidModuleConfigConverter.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToAndroidModuleConfigConverter.kt
@@ -46,7 +46,8 @@ class ConfigPojoToAndroidModuleConfigConverter {
 
             val resolvedDependencies = config.resolvedDependencies[moduleName]?.sortedBy { it.to }
                     ?.map { dependency -> DependencyConfig.ModuleDependencyConfig(dependency.to, dependency.method) } ?: emptyList()
-            dependencies = config.libraries?.let { resolvedDependencies + it } ?: resolvedDependencies
+            val resolvedDummyLocalJarLibsDependency = config.resolvedDummyLocalJarLibsDependencies[moduleName]?.let { listOf(it) } ?: emptyList()
+            dependencies = (config.libraries?: emptyList()) + resolvedDependencies + resolvedDummyLocalJarLibsDependency
 
             this.buildTypes = buildTypes
             this.productFlavorConfigs = productFlavorConfigs

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToModuleConfigConverter.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToModuleConfigConverter.kt
@@ -44,8 +44,8 @@ class ConfigPojoToModuleConfigConverter {
 
             moduleName = config.getModuleName(index)
 
-            val resolvedDummyFileTreeDependency = config.resolvedDummyLocalJarLibsDependencies[moduleName]?.let { listOf(it) } ?: emptyList()
-            dependencies = (config.resolvedDependencies[moduleName]?.map { DependencyConfig.ModuleDependencyConfig(it.to, it.method) } ?: listOf()) + resolvedDummyFileTreeDependency
+            val resolvedFileTreeDependency = config.resolvedLocalJarLibsDependencies[moduleName]?.let { listOf(it) } ?: emptyList()
+            dependencies = (config.resolvedDependencies[moduleName]?.map { DependencyConfig.ModuleDependencyConfig(it.to, it.method) } ?: listOf()) + resolvedFileTreeDependency
         }
     }
 }

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToModuleConfigConverter.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToModuleConfigConverter.kt
@@ -43,7 +43,9 @@ class ConfigPojoToModuleConfigConverter {
             generateTests = config.generateTests
 
             moduleName = config.getModuleName(index)
-            dependencies = config.resolvedDependencies[moduleName]?.map { DependencyConfig.ModuleDependencyConfig(it.to, it.method) } ?: listOf()
+
+            val resolvedDummyFileTreeDependency = config.resolvedDummyLocalJarLibsDependencies[moduleName]?.let { listOf(it) } ?: emptyList()
+            dependencies = (config.resolvedDependencies[moduleName]?.map { DependencyConfig.ModuleDependencyConfig(it.to, it.method) } ?: listOf()) + resolvedDummyFileTreeDependency
         }
     }
 }

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/GradleUtils.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/generators/GradleUtils.kt
@@ -21,12 +21,15 @@ import com.google.androidstudiopoet.gradle.Expression
 import com.google.androidstudiopoet.gradle.StringStatement
 import com.google.androidstudiopoet.models.Dependency
 import com.google.androidstudiopoet.models.LibraryDependency
+import com.google.androidstudiopoet.models.FileTreeDependency
 import com.google.androidstudiopoet.models.ModuleDependency
 import com.google.androidstudiopoet.models.Repository
 
 fun ModuleDependency.toExpression() = Expression(this.method, "project(':${this.name}')")
 
 fun LibraryDependency.toExpression() = Expression(this.method, "\"${this.name}\"")
+
+fun FileTreeDependency.toExpression() = Expression(this.method, "fileTree(dir: '${this.dir}', include: ['${this.include}'])")
 
 fun String.toApplyPluginExpression() = Expression("apply plugin:", "'$this'")
 
@@ -44,5 +47,6 @@ fun Repository.Remote.toExpression() = Closure("maven", listOf(Expression("url",
 fun Dependency.toExpression() = when (this) {
     is ModuleDependency -> this.toExpression()
     is LibraryDependency -> this.toExpression()
+    is FileTreeDependency -> this.toExpression()
     else -> null
 }

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/input/ConfigPOJO.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/input/ConfigPOJO.kt
@@ -86,7 +86,7 @@ class ConfigPOJO {
 
     var libraries: List<DependencyConfig.LibraryDependencyConfig>? = null
 
-    var dummyLocalJarLibsDependency: List<DependencyConfig.DummyLocalJarLibsDependencyConfig>? = null
+    var localJarLibsDependency: List<DependencyConfig.LocalJarLibsDependencyConfig>? = null
 
     var extraBuildFileLines: List<String>? = null
 
@@ -137,8 +137,8 @@ class ConfigPOJO {
         allDependencies
     }
 
-    val resolvedDummyLocalJarLibsDependencies: Map<String, DependencyConfig.DummyLocalJarLibsDependencyConfig> by lazy {
-        val givenDependency = dummyLocalJarLibsDependency
+    val resolvedLocalJarLibsDependencies: Map<String, DependencyConfig.LocalJarLibsDependencyConfig> by lazy {
+        val givenDependency = localJarLibsDependency
         givenDependency?.associateBy({it.moduleName}, {it}) ?: emptyMap()
     }
     private val allModuleNames: List<String> by lazy {

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/input/ConfigPOJO.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/input/ConfigPOJO.kt
@@ -86,6 +86,8 @@ class ConfigPOJO {
 
     var libraries: List<DependencyConfig.LibraryDependencyConfig>? = null
 
+    var dummyLocalJarLibsDependency: List<DependencyConfig.DummyLocalJarLibsDependencyConfig>? = null
+
     var extraBuildFileLines: List<String>? = null
 
     var extraAndroidBuildFileLines: List<String>? = null
@@ -135,6 +137,10 @@ class ConfigPOJO {
         allDependencies
     }
 
+    val resolvedDummyLocalJarLibsDependencies: Map<String, DependencyConfig.DummyLocalJarLibsDependencyConfig> by lazy {
+        val givenDependency = dummyLocalJarLibsDependency
+        givenDependency?.associateBy({it.moduleName}, {it}) ?: emptyMap()
+    }
     private val allModuleNames: List<String> by lazy {
         val moduleNames = mutableListOf<String>()
         (0 until androidModules).mapTo(moduleNames) {getAndroidModuleName(it)}

--- a/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/Dependencies.kt
+++ b/aspoet/src/main/kotlin/com/google/androidstudiopoet/models/Dependencies.kt
@@ -23,6 +23,8 @@ class AndroidModuleDependency(name: String, methodToCall: MethodToCall, method: 
 
 data class LibraryDependency(val method: String, val name: String) : Dependency
 
+data class FileTreeDependency(val method: String, val dir: String, val include: String, val count: Int) : Dependency
+
 data class GmavenBazelDependency(val name: String) : Dependency
 
 interface Dependency

--- a/aspoet/src/test/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToAndroidModuleConfigConverterTest.kt
+++ b/aspoet/src/test/kotlin/com/google/androidstudiopoet/converters/ConfigPojoToAndroidModuleConfigConverterTest.kt
@@ -106,7 +106,7 @@ class ConfigPojoToAndroidModuleConfigConverterTest {
 
             generateTests.assertEquals(GENERATE_TESTS)
             hasLaunchActivity.assertFalse()
-            dependencies!!.assertEquals(PURE_MODULE_DEPENDENCY_LIST + LIBRARY_LIST)
+            dependencies!!.sortedBy { it.toString() }.assertEquals((PURE_MODULE_DEPENDENCY_LIST + LIBRARY_LIST).sortedBy { it.toString() })
         }
     }
 
@@ -115,7 +115,7 @@ class ConfigPojoToAndroidModuleConfigConverterTest {
         val androidModuleConfig = converter.convert(configPOJO, 0, productFlavorConfigs, buildTypes)
         assertOn(androidModuleConfig) {
             hasLaunchActivity.assertTrue()
-            dependencies!!.assertEquals(listOf(DependencyConfig.ModuleDependencyConfig(ANDROID_MODULE_NAME_1, DEPENDENCY_METHOD)) + PURE_MODULE_DEPENDENCY_LIST + LIBRARY_LIST)
+            dependencies!!.sortedBy { it.toString() }.assertEquals((listOf(DependencyConfig.ModuleDependencyConfig(ANDROID_MODULE_NAME_1, DEPENDENCY_METHOD)) + PURE_MODULE_DEPENDENCY_LIST + LIBRARY_LIST).sortedBy { it.toString() })
             resourcesConfig!!.assertEquals(ResourcesConfig(ACTIVITY_COUNT + 2, ACTIVITY_COUNT + 5, ACTIVITY_COUNT))
         }
     }

--- a/aspoet/src/test/kotlin/com/google/androidstudiopoet/generators/ModuleBuildBazelGeneratorTest.kt
+++ b/aspoet/src/test/kotlin/com/google/androidstudiopoet/generators/ModuleBuildBazelGeneratorTest.kt
@@ -42,12 +42,13 @@ class ModuleBuildBazelGeneratorTest {
         "//library1",
         "//library2"
     ],
-)"""
+)
+"""
         verify(fileWriter).writeToFile(expected, "BUILD.bazel")
     }
 
     @Test
-    fun `generator applies dummy dependencies from the blueprint`() {
+    fun `generator applies local dependencies from the blueprint`() {
         val blueprint = getModuleBuildBazelBlueprint(dependencies = setOf(
             FileTreeDependency("implementation", "libs", "*.jar", 1)
         ))

--- a/aspoet/src/test/kotlin/com/google/androidstudiopoet/generators/ModuleBuildBazelGeneratorTest.kt
+++ b/aspoet/src/test/kotlin/com/google/androidstudiopoet/generators/ModuleBuildBazelGeneratorTest.kt
@@ -46,6 +46,28 @@ class ModuleBuildBazelGeneratorTest {
         verify(fileWriter).writeToFile(expected, "BUILD.bazel")
     }
 
+    @Test
+    fun `generator applies dummy dependencies from the blueprint`() {
+        val blueprint = getModuleBuildBazelBlueprint(dependencies = setOf(
+            FileTreeDependency("implementation", "libs", "*.jar", 1)
+        ))
+        buildBazelGenerator.generate(blueprint)
+            val expected = """java_library(
+    name = "target_name",
+    srcs = glob(["src/main/java/**/*.java"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":imported"
+    ],
+)
+java_import(
+    name = "imported",
+    constraints = ["android"],
+    jars = glob(["libs/*.jar}"]),
+)"""
+        verify(fileWriter).writeToFile(expected, "BUILD.bazel")
+    }
+
     private fun getModuleBuildBazelBlueprint(dependencies: Set<Dependency> = setOf()): ModuleBuildBazelBlueprint {
         return mock<ModuleBuildBazelBlueprint>().apply {
             whenever(this.targetName).thenReturn("target_name")

--- a/aspoet/src/test/kotlin/com/google/androidstudiopoet/generators/ModuleBuildGradleGeneratorTest.kt
+++ b/aspoet/src/test/kotlin/com/google/androidstudiopoet/generators/ModuleBuildGradleGeneratorTest.kt
@@ -17,6 +17,7 @@ limitations under the License.
 package com.google.androidstudiopoet.generators
 
 import com.google.androidstudiopoet.models.Dependency
+import com.google.androidstudiopoet.models.FileTreeDependency
 import com.google.androidstudiopoet.models.ModuleBuildGradleBlueprint
 import com.google.androidstudiopoet.models.LibraryDependency
 import com.google.androidstudiopoet.models.ModuleDependency
@@ -58,6 +59,20 @@ targetCompatibility = "1.8""""
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8""""
         verify(fileWriter).writeToFile(expected, "path")
+    }
+
+    @Test
+    fun `generator applies dummy libraries from the blueprint`() {
+      val blueprint = getModuleBuildGradleBlueprint(dependencies = setOf(
+        FileTreeDependency("implementation", "libs", "*.jar", 1)
+      ))
+      buildGradleGenerator.generate(blueprint)
+      val expected = """dependencies {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+}
+sourceCompatibility = "1.8"
+targetCompatibility = "1.8""""
+      verify(fileWriter).writeToFile(expected, "path")
     }
 
     @Test

--- a/aspoet/src/test/kotlin/com/google/androidstudiopoet/generators/ModuleBuildGradleGeneratorTest.kt
+++ b/aspoet/src/test/kotlin/com/google/androidstudiopoet/generators/ModuleBuildGradleGeneratorTest.kt
@@ -62,7 +62,7 @@ targetCompatibility = "1.8""""
     }
 
     @Test
-    fun `generator applies dummy libraries from the blueprint`() {
+    fun `generator applies local libraries from the blueprint`() {
       val blueprint = getModuleBuildGradleBlueprint(dependencies = setOf(
         FileTreeDependency("implementation", "libs", "*.jar", 1)
       ))

--- a/aspoet/src/test/kotlin/com/google/androidstudiopoet/generators/android_modules/AndroidModuleBuildBazelGeneratorTest.kt
+++ b/aspoet/src/test/kotlin/com/google/androidstudiopoet/generators/android_modules/AndroidModuleBuildBazelGeneratorTest.kt
@@ -33,7 +33,8 @@ android_binary(
         "//library1",
         gmaven_artifact("external:aar:1")
     ],
-)"""
+)
+"""
         verify(fileWriter).writeToFile(expected, "BUILD.bazel")
     }
 
@@ -61,12 +62,13 @@ android_library(
         gmaven_artifact("external:aar:1"),
         gmaven_artifact("external:aar:2")
     ],
-)"""
+)
+"""
         verify(fileWriter).writeToFile(expected, "BUILD.bazel")
     }
 
     @Test
-    fun `generator applies dummy libraries from the blueprint`() {
+    fun `generator applies local libraries from the blueprint`() {
         val blueprint = getAndroidBuildBazelBlueprint(dependencies = setOf(
             FileTreeDependency("implementation","libs", "*.jar", 1),
         ))
@@ -105,7 +107,8 @@ android_library(
     manifest = "src/main/AndroidManifest.xml",
     custom_package = "com.foo",
     visibility = ["//visibility:public"],
-)"""
+)
+"""
         verify(fileWriter).writeToFile(expected, "BUILD.bazel")
     }
 

--- a/aspoet/src/test/kotlin/com/google/androidstudiopoet/generators/android_modules/AndroidModuleBuildGradleGeneratorTest.kt
+++ b/aspoet/src/test/kotlin/com/google/androidstudiopoet/generators/android_modules/AndroidModuleBuildGradleGeneratorTest.kt
@@ -179,7 +179,7 @@ class AndroidModuleBuildGradleGeneratorTest {
     }
 
   @Test
-  fun `generator applies dummy libraries from the blueprint`() {
+  fun `generator applies local libraries from the blueprint`() {
     val blueprint = getAndroidBuildGradleBlueprint(dependencies = setOf(
       FileTreeDependency("implementation", "libs", "*.jar", 10),
     ))

--- a/aspoet/src/test/kotlin/com/google/androidstudiopoet/generators/android_modules/AndroidModuleBuildGradleGeneratorTest.kt
+++ b/aspoet/src/test/kotlin/com/google/androidstudiopoet/generators/android_modules/AndroidModuleBuildGradleGeneratorTest.kt
@@ -178,6 +178,40 @@ class AndroidModuleBuildGradleGeneratorTest {
         verify(fileWriter).writeToFile(expected, "path")
     }
 
+  @Test
+  fun `generator applies dummy libraries from the blueprint`() {
+    val blueprint = getAndroidBuildGradleBlueprint(dependencies = setOf(
+      FileTreeDependency("implementation", "libs", "*.jar", 10),
+    ))
+    androidModuleBuildGradleGenerator.generate(blueprint)
+    val expected = """
+            android {
+                compileSdkVersion 0
+                defaultConfig {
+                    minSdkVersion 0
+                    targetSdkVersion 0
+                    versionCode 1
+                    versionName "1.0"
+                    multiDexEnabled true
+                    testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+                }
+                buildTypes {
+                    release {
+                        minifyEnabled false
+                        proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+                    }
+                }
+                compileOptions {
+                    targetCompatibility 1.8
+                    sourceCompatibility 1.8
+                }
+            }
+            dependencies {
+                implementation fileTree(dir: 'libs', include: ['*.jar'])
+            }""".trimIndent()
+    verify(fileWriter).writeToFile(expected, "path")
+  }
+
     @Test
     fun `generator applies flavors and dimensions from the blueprint`() {
         val blueprint = getAndroidBuildGradleBlueprint(


### PR DESCRIPTION
I need to create a fake gradle project with a huge amount of jar libs as deps. So I create this change. I think this would be useful since it's common to encounter freeze due to a project with a huge amount of libs. And we need to create such fake project for debugging.

user can 1 dummy jar lib to module0 by using "dummyLocalJarLibsDependency": [{"moduleName": "module0", "count":  "1"}]. It will make sure the dummy jar file is generated locally i.e. you can sync project without issue.
